### PR TITLE
Adiciona licenciamento do projeto

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -1,0 +1,31 @@
+# Pilot Licensing
+
+## For all codebase
+
+```
+Copyright (c) 2017-present Pagar.me Pagamentos S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this library except in compliance with the License. You may obtain a copy of
+the License at
+
+www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.```
+```
+
+## For all asset, documentation and issue contents
+
+```
+Copyright (c) 2017-present Pagar.me Pagamentos S.A.
+
+All assets, documentation and issue content in this work are licensed under the
+Creative Commons Attribution 4.0 International License. To view a copy of this
+license, visit
+
+http://creativecommons.org/licenses/by/4.0
+```
+

--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ This project is under development.
 
 **TODO:** Add information on how to contribute.
 
+## Licensing
+
+See [LICENSES](LICENSES.md).


### PR DESCRIPTION
Este PR adiciona a parte de licenciamento do projeto.

Acho importante ressaltar que o conteúdo de issues, pull-requests e também
todos os assets gráficos também precisam ser licenciados, para a seguranca
da companhia e também dos usuários do conteúdo.

Dado isso, selecionei o seguinte licenciamento:

* Base de código: **Apache 2.0 License**
* Gráficos, PRs e issues: **Creative Commons Atribution 4.0 International**

Gostaria da revisão dos senhores, e se posível da galera do jurídico também.
cc @filipedeschamps @jonathanlima