### PR TITLE
Fix Git diff test not erroring CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 
 script:
   - yarn
-  - git diff
+  - test -z "$(git diff)"
   - yarn lint
   - yarn build
   - yarn test


### PR DESCRIPTION
The `git diff` command used alone doesn't return an exit status. To make
git return an exit status when there are changes we need to use
`--exit-code`.