### PR TITLE
Fix eslint not failing Travis build

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -61,7 +61,7 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
-    "lint": "eslint './src/**/*.js'; stylelint './src/**/*.css'",
+    "lint": "eslint './src/**/*.js' && stylelint './src/**/*.css'",
     "test": "node scripts/test.js --env=jsdom",
     "storybook": "start-storybook -p 6006",
     "percy": "build-storybook && percy-storybook --widths=640,1280",


### PR DESCRIPTION
Assim, o `yarn lint` localmente acusa alguns erros, porém com os mesmos erros ele passa no CI.

Então imaginei que isso poderia ajudar, porém vi que no CI ele está passando pelo lint, acusa os erros porém ele não quebra o CI com os erros de linter https://travis-ci.org/pagarme/pilot/builds/272586069#L468

![image](https://user-images.githubusercontent.com/736728/30126621-db1e0b9e-9312-11e7-8105-3762cca917cf.png)
