### PR TITLE
Move .eslintrc to package.json

### DIFF
--- a/webapp/.eslintrc
+++ b/webapp/.eslintrc
@@ -1,9 +1,0 @@
-{
-  "extends": ["pagarme-react"],
-  "env": {
-    "browser": true
-  },
-  "rules": {
-    "react/jsx-filename-extension": 0
-  }
-}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -108,7 +108,11 @@
   "eslintConfig": {
     "extends": "pagarme-react",
     "env": {
+      "browser": true,
       "jest": true
+    },
+    "rules": {
+      "react/jsx-filename-extension": 0
     }
   },
   "stylelint": {


### PR DESCRIPTION
create-react-app stores eslint configuration into `package.json`. When I
initially bootstraped the repo I've mistakenly crated an `.eslintrc` file.

This PR merges `.eslintrc` config into `package.json`.