### PR TITLE
chore: add cssnext to storybook

### DIFF
--- a/webapp/config/webpack.config.dev.js
+++ b/webapp/config/webpack.config.dev.js
@@ -135,6 +135,11 @@ module.exports = {
               formatter: stylelintFormatter,
               plugins: () => [
                 require('stylelint'),
+                require('postcss-import'),
+                require('postcss-url')({
+                  url: postcssUrlRebase,
+                }),
+                require('postcss-cssnext'),
               ],
             },
             loader: require.resolve('postcss-loader'),

--- a/webapp/config/webpack.config.prod.js
+++ b/webapp/config/webpack.config.prod.js
@@ -123,7 +123,6 @@ module.exports = {
             options: {
               formatter: eslintFormatter,
               eslintPath: require.resolve('eslint'),
-              
             },
             loader: require.resolve('eslint-loader'),
           },
@@ -139,6 +138,11 @@ module.exports = {
               formatter: stylelintFormatter,
               plugins: () => [
                 require('stylelint'),
+                require('postcss-import'),
+                require('postcss-url')({
+                  url: postcssUrlRebase,
+                }),
+                require('postcss-cssnext'),
               ],
             },
             loader: require.resolve('postcss-loader'),

--- a/webapp/config/webpack.config.storybook.js
+++ b/webapp/config/webpack.config.storybook.js
@@ -1,5 +1,6 @@
 const paths = require('./paths.js')
 const eslintFormatter = require('react-dev-utils/eslintFormatter')
+const stylelintFormatter = require('./stylelintFormatter')
 const postcssUrlRebase = require('./postcssUrlRebase')
 
 module.exports = {
@@ -15,6 +16,33 @@ module.exports = {
               eslintPath: require.resolve('eslint'),
             },
             loader: require.resolve('eslint-loader'),
+          },
+        ],
+        include: paths.appSrc,
+      },
+      {
+        test: /\.css$/,
+        enforce: 'pre',
+        use: [
+          {
+            options: {
+              formatter: stylelintFormatter,
+              plugins: () => [
+                require('stylelint'),
+                require('postcss-import'),
+                require('postcss-url')({
+                  url: postcssUrlRebase,
+                }),
+                require('postcss-cssnext')({
+                  features: {
+                    customProperties: {
+                      strict: false,
+                    },
+                  },
+                }),
+              ],
+            },
+            loader: require.resolve('postcss-loader'),
           },
         ],
         include: paths.appSrc,
@@ -37,7 +65,15 @@ module.exports = {
               ident: 'postcss',
               plugins: () => [
                 require('postcss-import'),
-                require('postcss-url')({ url: postcssUrlRebase }),
+                require('postcss-url')({
+                  url: postcssUrlRebase,
+                }),
+                require('postcss-cssnext')({
+                  // We don't transpile CSS variables module in Storybook
+                  features: {
+                    customProperties: false,
+                  },
+                }),
               ],
             },
           },


### PR DESCRIPTION
This adds cssnext to Storybook. To keep font book compatible with recent
browsers, we disable customProperties in cssnext configuration. Older IE
users still need to enable this flag to be able to see colors in components.