### PR TITLE
switch: refactor p element to use div

### DIFF
--- a/webapp/stories/Switch/index.js
+++ b/webapp/stories/Switch/index.js
@@ -5,6 +5,10 @@ import { action } from '@storybook/addon-actions'
 
 import Switch from '../../src/components/Switch'
 
+const Row = ({ children })=> (
+  <div style={{ padding: '0.5em' }}>{children}</div>
+)
+
 
 class SwitchMeWell extends Component {
   constructor (props) {
@@ -31,22 +35,22 @@ class SwitchMeWell extends Component {
 storiesOf('Switch', module)
   .add('checked', () => (
     <div>
-      <p>
+      <Row>
         <SwitchMeWell checked />
-      </p>
+      </Row>
 
-      <p>
+      <Row>
         <SwitchMeWell checked={false} />
-      </p>
+      </Row>
     </div>
   ))
   .add('disabled', () => (
     <div>
-      <p>
+      <Row>
         <SwitchMeWell disabled checked /> 
-      </p>
-      <p>
+      </Row>
+      <Row>
         <SwitchMeWell disabled checked={false} /> 
-      </p>
+      </Row>
     </div>
   ))

--- a/webapp/stories/__snapshots__/storyshots.test.js.snap
+++ b/webapp/stories/__snapshots__/storyshots.test.js.snap
@@ -7013,7 +7013,13 @@ exports[`Storyshots RadioGroup success 1`] = `
 
 exports[`Storyshots Switch checked 1`] = `
 <div>
-  <p>
+  <div
+    style={
+      Object {
+        "padding": "0.5em",
+      }
+    }
+  >
     <div>
       <div
         className=""
@@ -7031,8 +7037,14 @@ exports[`Storyshots Switch checked 1`] = `
         </span>
       </div>
     </div>
-  </p>
-  <p>
+  </div>
+  <div
+    style={
+      Object {
+        "padding": "0.5em",
+      }
+    }
+  >
     <div>
       <div
         className=""
@@ -7050,13 +7062,19 @@ exports[`Storyshots Switch checked 1`] = `
         </span>
       </div>
     </div>
-  </p>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Switch disabled 1`] = `
 <div>
-  <p>
+  <div
+    style={
+      Object {
+        "padding": "0.5em",
+      }
+    }
+  >
     <div>
       <div
         className="undefined"
@@ -7074,8 +7092,14 @@ exports[`Storyshots Switch disabled 1`] = `
         </span>
       </div>
     </div>
-  </p>
-  <p>
+  </div>
+  <div
+    style={
+      Object {
+        "padding": "0.5em",
+      }
+    }
+  >
     <div>
       <div
         className="undefined"
@@ -7093,7 +7117,7 @@ exports[`Storyshots Switch disabled 1`] = `
         </span>
       </div>
     </div>
-  </p>
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
Este PR remove uma `div` que estava dentro de um `p` no storybook! Remove um warning chato!