### PR TITLE
buttons: fix proptypes

### DIFF
--- a/webapp/src/components/Button/index.js
+++ b/webapp/src/components/Button/index.js
@@ -22,7 +22,7 @@ function Button ({ onClick, variant, base, color, size, children, type }) {
 }
 
 Button.propTypes = {
-  type: PropTypes.string,
+  type: PropTypes.oneOf(['button', 'submit', 'reset']),
   onClick: PropTypes.func,
   variant: PropTypes.oneOf([
     'flat', 'gradient', 'outline', 'dashed', 'clean', 'block',


### PR DESCRIPTION
Button has only 3 possible type values. Proptypes should accept one of those 3 instead of just a `string`