### PR TITLE
Fix Travis failing on PRs from forks because of Percy token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ script:
   - yarn lint
   - yarn build
   - yarn test
-  - yarn percy
+  - yarn percy; true
 


### PR DESCRIPTION
Currently Percy doesn't have a way to be ran on open source projects.

Sharing the private project key isn't an option, as there isn't a way to generate a new key on Percy.

To fix this issue, make percy script in `.travis.yml` always return true.