### PR TITLE
Add shouldComponentUpdate method to CheckboxGroup

### DIFF
--- a/webapp/src/components/CheckboxGroup/index.js
+++ b/webapp/src/components/CheckboxGroup/index.js
@@ -21,6 +21,10 @@ class CheckboxGroup extends React.Component {
     this.handleChange = this.handleChange.bind(this)
   }
 
+  shouldComponentUpdate (nextProps) {
+    return !equals(this.props, nextProps)
+  }
+
   handleChange (value) {
     const { disabled, values, onChange } = this.props
 


### PR DESCRIPTION
This is a performance improvement when various `CheckboxGroup` instances
are present on a single page.