### PR TITLE
dropdown: fix behaviour for default value

### DIFF
--- a/webapp/src/components/Dropdown/index.js
+++ b/webapp/src/components/Dropdown/index.js
@@ -86,15 +86,16 @@ class Dropdown extends React.Component {
             <select
               onChange={e => !this.props.disabled && this.selectOption(e.target.value)}
               disabled={this.props.disabled}
+              defaultValue="title"
             >
-              {this.props.title &&
-                <option
-                  disabled
-                  className={classnames(style.option, style.disabledOption)}
-                >
-                  {this.props.title}
-                </option>
-              }
+              <option
+                disabled
+                hidden
+                value="title"
+                className={classnames(style.option, style.disabledOption)}
+              >
+                {this.props.title}
+              </option>
               {dropdownOptions}
             </select>
           </div>

--- a/webapp/stories/__snapshots__/storyshots.test.js.snap
+++ b/webapp/stories/__snapshots__/storyshots.test.js.snap
@@ -5450,10 +5450,18 @@ exports[`Storyshots Forms Dropdown 1`] = `
             >
               Selecione
               <select
+                defaultValue="title"
                 disabled={false}
                 onChange={[Function]}
               >
-                
+                <option
+                  className=""
+                  disabled={true}
+                  hidden={true}
+                  value="title"
+                >
+                  
+                </option>
                 <option
                   className=""
                   value="leonardo"
@@ -5531,12 +5539,15 @@ exports[`Storyshots Forms Dropdown 1`] = `
             >
               Selecione alguem
               <select
+                defaultValue="title"
                 disabled={false}
                 onChange={[Function]}
               >
                 <option
                   className=""
                   disabled={true}
+                  hidden={true}
+                  value="title"
                 >
                   Selecione alguem
                 </option>
@@ -5617,12 +5628,15 @@ exports[`Storyshots Forms Dropdown 1`] = `
             >
               Selecione alguem
               <select
+                defaultValue="title"
                 disabled={true}
                 onChange={[Function]}
               >
                 <option
                   className=""
                   disabled={true}
+                  hidden={true}
+                  value="title"
                 >
                   Selecione alguem
                 </option>
@@ -5703,10 +5717,18 @@ exports[`Storyshots Forms Dropdown 1`] = `
             >
               Selecione
               <select
+                defaultValue="title"
                 disabled={true}
                 onChange={[Function]}
               >
-                
+                <option
+                  className=""
+                  disabled={true}
+                  hidden={true}
+                  value="title"
+                >
+                  
+                </option>
                 <option
                   className=""
                   value="leonardo"
@@ -5784,10 +5806,18 @@ exports[`Storyshots Forms Dropdown 1`] = `
             >
               Selecione
               <select
+                defaultValue="title"
                 disabled={false}
                 onChange={[Function]}
               >
-                
+                <option
+                  className=""
+                  disabled={true}
+                  hidden={true}
+                  value="title"
+                >
+                  
+                </option>
                 <option
                   className=""
                   value="leonardo"
@@ -5869,10 +5899,18 @@ exports[`Storyshots Forms Dropdown 1`] = `
             >
               Selecione
               <select
+                defaultValue="title"
                 disabled={false}
                 onChange={[Function]}
               >
-                
+                <option
+                  className=""
+                  disabled={true}
+                  hidden={true}
+                  value="title"
+                >
+                  
+                </option>
                 <option
                   className=""
                   value="leonardo"


### PR DESCRIPTION
when there's no select option with a empty value and the select doesn't
have a default value, the first one that is not disabled is selected, so
even if the `prop.value` is empty, the `select` value isn't