### PR TITLE
date-selector: add strings prop for i18n

### DIFF
--- a/webapp/src/components/DateSelector/DateSelector.test.js
+++ b/webapp/src/components/DateSelector/DateSelector.test.js
@@ -45,6 +45,34 @@ describe('DateSelector', () => {
     expect(component.find('ol li input').length).toBe(4)
   })
 
+  it('should render buttons in default translation', () => {
+    const component = mount(
+      <DateSelector
+        presets={presets}
+        dates={defaultDates}
+      />
+    )
+
+    expect(component.find(Button).at(0).text()).toBe('cancel')
+    expect(component.find(Button).at(1).text()).toBe('confirm period')
+  })
+
+  it('should render buttons in portuguese', () => {
+    const component = mount(
+      <DateSelector
+        presets={presets}
+        dates={defaultDates}
+        strings={{
+          cancel: 'Cancelar',
+          confirmPeriod: 'Confirmar período',
+        }}
+      />
+    )
+
+    expect(component.find(Button).at(0).text()).toBe('Cancelar')
+    expect(component.find(Button).at(1).text()).toBe('Confirmar período')
+  })
+
   it('should call onConfirm', () => {
     const onConfirm = jest.fn()
 

--- a/webapp/src/components/DateSelector/index.js
+++ b/webapp/src/components/DateSelector/index.js
@@ -34,6 +34,18 @@ import './react-dates.css'
 
 const START_DATE = 'startDate'
 
+const defaultStrings = {
+  cancel: 'cancel',
+  confirmPeriod: 'confirm period',
+  custom: 'custom',
+  day: 'day',
+  daySelected: 'day selected',
+  daysSelected: 'days selected',
+  noDayOrPeriodSelected: 'No day or period selected',
+  period: 'period',
+  today: 'today',
+}
+
 export default class DateSelector extends Component {
   constructor (props) {
     super(props)
@@ -44,6 +56,7 @@ export default class DateSelector extends Component {
 
     this.instanceId = `dateselector-${shortid.generate()}`
 
+    this.getStrings = this.getStrings.bind(this)
     this.handleFocusChange = this.handleFocusChange.bind(this)
     this.handleDatesChange = this.handleDatesChange.bind(this)
     this.handlePresetChange = this.handlePresetChange.bind(this)
@@ -59,6 +72,13 @@ export default class DateSelector extends Component {
       if (dates) {
         this.setState({ dates })
       }
+    }
+  }
+
+  getStrings () {
+    return {
+      ...defaultStrings,
+      ...this.props.strings,
     }
   }
 
@@ -188,6 +208,13 @@ export default class DateSelector extends Component {
   renderActions () {
     const { start, end } = this.props.dates || {}
     const { preset } = this.state
+    const {
+      cancel,
+      confirmPeriod,
+      daySelected,
+      daysSelected,
+      noDayOrPeriodSelected,
+    } = this.getStrings()
 
     let daysCount = 0
 
@@ -200,9 +227,9 @@ export default class DateSelector extends Component {
     return (
       <div className={style.actions}>
         <div className={style.selectedDays}>
-          {daysCount === 0 ? 'Nenhum dia ou período selecionado' : null}
-          {daysCount === 1 ? '1 dia selecionado' : null}
-          {daysCount > 1 ? `${daysCount} dias selecionados` : null}
+          {daysCount === 0 ? noDayOrPeriodSelected : null}
+          {daysCount === 1 ? `1 ${daySelected}` : null}
+          {daysCount > 1 ? `${daysCount} ${daysSelected}` : null}
         </div>
         <Button
           variant="clean"
@@ -210,7 +237,7 @@ export default class DateSelector extends Component {
           size="small"
           onClick={this.handleCancel}
         >
-          Cancelar
+          {cancel}
         </Button>
         <span className={style.separator} />
         <Button
@@ -218,33 +245,40 @@ export default class DateSelector extends Component {
           size="small"
           onClick={this.handleConfirm}
         >
-          Confirmar Período
+          {confirmPeriod}
         </Button>
       </div>
     )
   }
 
   renderSidebar () {
+    const {
+      custom,
+      day,
+      period,
+      today,
+    } = this.getStrings()
+
     return (
       <div className={style.sidebar}>
         <ol>
           {this.renderPreset({
             key: 'today',
-            title: 'Hoje',
+            title: today,
             date: () => 0,
           })}
           {this.renderPresets(this.props.presets)}
           <li>
-            <h2>Personalizado:</h2>
+            <h2>{`${custom}:`}</h2>
             <ol>
               {this.renderPreset({
                 key: 'single',
-                title: 'Dia',
+                title: day,
                 date: () => -1,
               })}
               {this.renderPreset({
                 key: 'range',
-                title: 'Período',
+                title: period,
                 date: () => -3,
               })}
             </ol>
@@ -286,6 +320,17 @@ DateSelector.propTypes = {
       date: func,
     })),
   })),
+  strings: shape({
+    cancel: string,
+    confirmPeriod: string,
+    custom: string,
+    days: string,
+    daySelected: string,
+    daysSelected: string,
+    noDayOrPeriodSelected: string,
+    period: string,
+    today: string,
+  }),
 }
 
 DateSelector.defaultProps = {
@@ -295,4 +340,5 @@ DateSelector.defaultProps = {
   onFocusChange: () => undefined,
   focusedInput: START_DATE,
   presets: [],
+  strings: defaultStrings,
 }

--- a/webapp/stories/__snapshots__/storyshots.test.js.snap
+++ b/webapp/stories/__snapshots__/storyshots.test.js.snap
@@ -1573,7 +1573,7 @@ exports[`Storyshots DateSelector All types 1`] = `
           <label
             htmlFor="dateselector-always-the-same-string-preset-today"
           >
-            Hoje
+            today
           </label>
         </li>
         <ol>
@@ -1639,7 +1639,7 @@ exports[`Storyshots DateSelector All types 1`] = `
         </ol>
         <li>
           <h2>
-            Personalizado:
+            custom:
           </h2>
           <ol>
             <li>
@@ -1653,7 +1653,7 @@ exports[`Storyshots DateSelector All types 1`] = `
               <label
                 htmlFor="dateselector-always-the-same-string-preset-single"
               >
-                Dia
+                day
               </label>
             </li>
             <li>
@@ -1667,7 +1667,7 @@ exports[`Storyshots DateSelector All types 1`] = `
               <label
                 htmlFor="dateselector-always-the-same-string-preset-range"
               >
-                Período
+                period
               </label>
             </li>
           </ol>
@@ -4787,7 +4787,7 @@ exports[`Storyshots DateSelector All types 1`] = `
         <div
           className={undefined}
         >
-          1 dia selecionado
+          1 day selected
         </div>
         <button
           className=""
@@ -4795,7 +4795,7 @@ exports[`Storyshots DateSelector All types 1`] = `
           onClick={[Function]}
           type="button"
         >
-          Cancelar
+          cancel
         </button>
         <span
           className={undefined}
@@ -4806,7 +4806,7 @@ exports[`Storyshots DateSelector All types 1`] = `
           onClick={[Function]}
           type="button"
         >
-          Confirmar Período
+          confirm period
         </button>
       </div>
     </div>


### PR DESCRIPTION
@derekstavis 

This PR is only adding translation to the DateSelector component regarding issue #342. I want you to see if I am doing it correctly first, so I can work on the other components that also need translations.

---

### Regarding momentJS locale on each component. 
With the current project setup, all components are respecting the global locale that is set for the entire application on [this file](https://github.com/pagarme/pilot/blob/master/webapp/src/locale/index.js). If I give the user the option to update the locale on a single component, the entire application will also change.

One solution for this is to put "days of the week" / "months" terms by hand inside the component and outside momentJS, maybe together with the strings props. Or we can leave the component "reading" the locale that is set on each particular project, as it is.

What do you think?

---

### Percy visual regression test

This PR seems to break Percy tests.
