### PR TITLE
add: first deploy process in ci/cd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,3 +33,159 @@ jobs:
             - packages/cockpit/node_modules
             - packages/pilot/node_modules
           key: dependencies-{{ checksum "yarn.lock" }}
+  build_stg:
+    docker:
+      - image: node:9
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - dependencies-{{ checksum "yarn.lock" }}
+          - dependencies-
+
+      - run: yarn
+
+      - run: |
+          cd packages/cockpit
+          yarn build
+
+      - run: |
+          cd packages
+          cp -rf pilot pilot-latest
+          cp -rf pilot pilot-${CIRCLE_TAG}
+          cd pilot-latest
+          export PUBLIC_URL_REGEX='https:\/\/beta.dashboard.stg.pagarme.net\/latest'
+          export PUBLIC_URL='https://beta.dashboard.stg.pagarme.net/latest'
+          sed -e 's/\".\"/"'$PUBLIC_URL_REGEX'\"/g' package.json > package.json.bak
+          cp package.json.bak package.json
+          yarn build
+          cd ../pilot-${CIRCLE_TAG}
+          export PUBLIC_URL_REGEX='https:\/\/beta.dashboard.stg.pagarme.net\/versions\/'${CIRCLE_TAG}
+          export PUBLIC_URL='https://beta.dashboard.stg.pagarme.net/versions/'${CIRCLE_TAG}
+          sed -e 's/\".\"/"'$PUBLIC_URL_REGEX'\"/g' package.json > package.json.bak
+          cp package.json.bak package.json
+          yarn build
+      - run: |
+         cd packages
+         mkdir builds
+         mv pilot-latest/build builds/pilot-latest
+         mv pilot-${CIRCLE_TAG}/build builds/pilot-${CIRCLE_TAG}
+      - persist_to_workspace:
+          root: packages
+          paths:
+            - builds
+  build_prd:
+    docker:
+      - image: node:9
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - dependencies-{{ checksum "yarn.lock" }}
+          - dependencies-
+
+      - run: yarn
+
+      - run: |
+          cd packages/cockpit
+          yarn build
+
+      - run: |
+          cd packages/pilot
+          export PUBLIC_URL_REGEX='https:\/\/beta.dashboard.pagar.me'
+          export PUBLIC_URL='https://beta.dashboard.pagar.me'
+          sed -e 's/\".\"/"'$PUBLIC_URL_REGEX'\"/g' package.json > package.json.bak
+          cp package.json.bak package.json
+          yarn build
+      - persist_to_workspace:
+          root: packages
+          paths:
+            - pilot/build
+  deploy_stg:
+    machine:
+        enabled: true
+    working_directory: ~/repo
+
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Deploy to S3 files of version for stg
+          command: |
+            cd builds
+            mv pilot-latest latest
+            mkdir -p versions
+            mv pilot-${CIRCLE_TAG} versions/${CIRCLE_TAG}
+            aws s3 sync . s3://beta.dashboard.stg.pagarme.net
+            aws cloudfront create-invalidation --distribution-id $CDN_DISTRIBUTION_ID --paths "/latest/*"
+  deploy_prd:
+    machine:
+        enabled: true
+    working_directory: ~/repo
+
+    steps:
+      - attach_workspace:
+          at: ~/repo/
+      - run:
+          name: Deploy to S3 files of version fo prod
+          command: |
+            cd pilot/build
+            AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_PRD AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_PRD aws s3 sync . s3://beta.dashboard.prd.pagarme.net
+            AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_PRD AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_PRD aws cloudfront create-invalidation --distribution-id $PRD_CDN_DISTRIBUTION_ID --paths "/*"
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+    - build:
+        filters:
+          tags:
+            only: /^v.*/
+    - build_stg:
+        requires:
+        - build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v([0-9]+).([0-9]+).([0-9]+).*$/
+    - deploy_stg:
+        requires:
+        - build_stg
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v([0-9]+).([0-9]+).([0-9]+).*$/
+    - hold:
+        type: approval
+        requires:
+          - deploy_stg
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v([0-9]+).([0-9]+).([0-9]+)$/
+    - build_prd:
+        requires:
+        - hold
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v([0-9]+).([0-9]+).([0-9]+).*$/
+    - deploy_prd:
+        requires:
+        - build_prd
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v([0-9]+).([0-9]+).([0-9]+)$/

--- a/packages/pilot/package.json
+++ b/packages/pilot/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pilot",
   "version": "0.1.0",
+  "homepage": ".",
   "private": true,
   "dependencies": {
     "classnames": "2.2.5",


### PR DESCRIPTION
we add cd process in ci/cd process on circleci build
we now have staging/production environments and this will work like these:

- we use git tag for control
- `v<MAJOR>.<MINOR>.<PATCH>-rc<RELEASE-CANDIDATE-NUMBER>` wil be send to staging in
  https://beta.dashboard.stg.pagarme.net/latest/index.html or
  https://beta.dashboard.stg.pagarme.net/versions/v0.1.0-rc12/index.html
- staging versions in /versions will be enabled in 30 days
- latest stage build will be stored in /latest/index.html
- `v<MAJOR>.<MINOR>.<PATCH>` will be send to production in
  https://beta.dashboard.pagar.me
- producion process will send first in staging to be approved and later
  will be sent to production.
- approval process will be done in circleci interface