### PR TITLE
Add review step to transaction details

### DIFF
--- a/packages/cockpit/src/transactions/details/index.js
+++ b/packages/cockpit/src/transactions/details/index.js
@@ -60,10 +60,11 @@ const fetchRecipients = uncurryN(2, client =>
 
 const details = client => transactionId =>
   props({
-    transaction: client.transactions.find({ id: transactionId }),
-    gatewayOperations: client.gatewayOperations.find({ transactionId }),
+    antifraudAnalyses: client.antifraudAnalyses.find({ transactionId }),
     chargebackOperations: client.chargebackOperations.find({ transactionId }),
+    gatewayOperations: client.gatewayOperations.find({ transactionId }),
     payables: client.payables.find({ transactionId }),
+    transaction: client.transactions.find({ id: transactionId }),
   })
     .then(data => fetchRecipients(client, data)
       .then(assoc('split_rules', __, data)))

--- a/packages/cockpit/src/transactions/details/mocks/expectedResultAntifraud.json
+++ b/packages/cockpit/src/transactions/details/mocks/expectedResultAntifraud.json
@@ -1,0 +1,76 @@
+{
+  "transaction": {
+    "acquirer": {
+      "name": "pagarme",
+      "response_code": "0000",
+      "sequence_number": "3514521",
+      "transaction_id": "3514521"
+    },
+    "amount": 21050,
+    "antifraud": null,
+    "boleto": null,
+    "card": {
+      "brand_name": "visa",
+      "capture_method": null,
+      "first_digits": "411111",
+      "holder_name": "Mateus Noguez Moog",
+      "international": true,
+      "last_digits": "1111",
+      "pin_mode": null
+    },
+    "created_at": "2018-05-17T17:28:26.998Z",
+    "customer": {
+      "birth_date": "1965-01-01T00:00:00.000Z",
+      "country": "br",
+      "document_number": null,
+      "document_type": "cpf",
+      "email": "mateusmoog@yahoo.com",
+      "name": "Morpheus Fishburne",
+      "phones": [
+        "+5511999998888",
+        "+5511888889999"
+      ]
+    },
+    "external_id": null,
+    "id": 3514521,
+    "metadata": {},
+    "operations": [
+      {
+        "created_at": "2018-05-17T17:28:27.778Z",
+        "cycle": null,
+        "id": "go_cjhat6u2e0bje5y3tcngama5q",
+        "status": "pending",
+        "type": "manual_review"
+      },
+      {
+        "created_at": "2018-05-17T17:28:27.062Z",
+        "cycle": null,
+        "id": "go_cjhat6u2e0bje5y3tcngama5q",
+        "status": "refused",
+        "type": "analyze"
+      },
+      {
+        "created_at": "2018-05-17T17:28:27.067Z",
+        "cycle": null,
+        "id": "go_cjhat6u2j0bjg5y3tmszihqc7",
+        "status": "success",
+        "type": "authorize"
+      }
+    ],
+    "payment": {
+      "cost_amount": 70,
+      "installments": 1,
+      "mdr_amount": 0,
+      "method": "credit_card",
+      "net_amount": -70,
+      "paid_amount": 0,
+      "refund_amount": 0
+    },
+    "reason_code": null,
+    "recipients": [],
+    "soft_descriptor": null,
+    "status": "pending_review",
+    "status_reason": "antifraud",
+    "updated_at": "2018-05-17T17:28:27.872Z"
+  }
+}

--- a/packages/cockpit/src/transactions/details/mocks/fromRequestsAntifraud.json
+++ b/packages/cockpit/src/transactions/details/mocks/fromRequestsAntifraud.json
@@ -1,0 +1,269 @@
+{
+  "transaction": {
+    "object": "transaction",
+    "status": "pending_review",
+    "refuse_reason": null,
+    "status_reason": "antifraud",
+    "acquirer_response_code": "0000",
+    "acquirer_name": "pagarme",
+    "acquirer_id": "5925cd5bb0fdbdd02ce290b1",
+    "authorization_code": "517887",
+    "soft_descriptor": null,
+    "tid": 3514521,
+    "nsu": 3514521,
+    "date_created": "2018-05-17T17:28:26.998Z",
+    "date_updated": "2018-05-17T17:28:27.872Z",
+    "amount": 21050,
+    "authorized_amount": 21050,
+    "paid_amount": 0,
+    "refunded_amount": 0,
+    "installments": 1,
+    "id": 3514521,
+    "cost": 70,
+    "card_holder_name": "Mateus Noguez Moog",
+    "card_last_digits": "1111",
+    "card_first_digits": "411111",
+    "card_brand": "visa",
+    "card_pin_mode": null,
+    "postback_url": null,
+    "payment_method": "credit_card",
+    "capture_method": "ecommerce",
+    "antifraud_score": null,
+    "boleto_url": null,
+    "boleto_barcode": null,
+    "boleto_expiration_date": null,
+    "referer": "api_key",
+    "ip": "201.48.106.225",
+    "subscription_id": null,
+    "phone": null,
+    "address": null,
+    "customer": {
+      "object": "customer",
+      "id": 591949,
+      "external_id": "#591949",
+      "type": "individual",
+      "country": "br",
+      "document_number": null,
+      "document_type": "cpf",
+      "name": "Morpheus Fishburne",
+      "email": "mateusmoog@yahoo.com",
+      "phone_numbers": [
+        "+5511999998888",
+        "+5511888889999"
+      ],
+      "born_at": null,
+      "birthday": "1965-01-01",
+      "gender": null,
+      "date_created": "2018-05-17T17:28:26.801Z",
+      "documents": [
+        {
+          "object": "document",
+          "id": "doc_cjhat6tvg028l2g6dj90jasof",
+          "type": "cpf",
+          "number": "44444444444"
+        }
+      ]
+    },
+    "billing": {
+      "address": {
+        "object": "address",
+        "street": "Rua Matrix",
+        "complementary": null,
+        "street_number": "9999",
+        "neighborhood": "Rio Cotia",
+        "city": "Cotia",
+        "state": "sp",
+        "zipcode": "06714360",
+        "country": "br",
+        "id": 366361
+      },
+      "object": "billing",
+      "id": 57316,
+      "name": "Trinity Moss"
+    },
+    "shipping": {
+      "address": {
+        "object": "address",
+        "street": "Rua Matrix",
+        "complementary": null,
+        "street_number": "9999",
+        "neighborhood": "Rio Cotia",
+        "city": "Cotia",
+        "state": "sp",
+        "zipcode": "06714360",
+        "country": "br",
+        "id": 366362
+      },
+      "object": "shipping",
+      "id": 26081,
+      "name": "Neo Reeves",
+      "fee": 1000,
+      "delivery_date": "2000-12-21",
+      "expedited": true
+    },
+    "items": [
+      {
+        "object": "item",
+        "id": "b123",
+        "title": "Blue pill",
+        "unit_price": 10000,
+        "quantity": 1,
+        "category": null,
+        "tangible": true,
+        "venue": null,
+        "date": null
+      },
+      {
+        "object": "item",
+        "id": "r123",
+        "title": "Red pill",
+        "unit_price": 10000,
+        "quantity": 1,
+        "category": null,
+        "tangible": true,
+        "venue": null,
+        "date": null
+      }
+    ],
+    "card": {
+      "object": "card",
+      "id": "card_cjhat6u0e028m2g6dzpfobzjc",
+      "date_created": "2018-05-17T17:28:26.990Z",
+      "date_updated": "2018-05-17T17:28:27.944Z",
+      "brand": "visa",
+      "holder_name": "Mateus Noguez Moog",
+      "first_digits": "411111",
+      "last_digits": "1111",
+      "country": "UNITED STATES",
+      "fingerprint": "cj5bw4cio00000j23jx5l60cq",
+      "valid": false,
+      "expiration_date": "0922"
+    },
+    "split_rules": null,
+    "metadata": {},
+    "antifraud_metadata": {},
+    "reference_key": null,
+    "device": null,
+    "local_transaction_id": null,
+    "local_time": null,
+    "fraud_covered": true,
+    "order_id": null,
+    "risk_level": "high",
+    "receipt_url": null,
+    "payment": null
+  },
+  "gatewayOperations": [
+    {
+      "id": "go_cjhat6u280bjc5y3tiul1p0rq",
+      "date_created": "2018-05-17T17:28:27.056Z",
+      "date_updated": "2018-05-17T17:28:27.056Z",
+      "status": "waiting",
+      "fail_reason": null,
+      "type": "capture",
+      "rollbacked": false,
+      "model": "transaction",
+      "model_id": "3514521",
+      "group_id": "gog_cjhat6u280bjd5y3tiow89saw",
+      "next_group_id": null,
+      "request_id": "gr_cjhat6u1y0bjb5y3tb2bgkckg",
+      "started_at": null,
+      "ended_at": null,
+      "processor": null,
+      "processor_response_code": null,
+      "metadata": {
+        "environment": {}
+      }
+    },
+    {
+      "id": "go_cjhat6u2e0bje5y3tcngama5q",
+      "date_created": "2018-05-17T17:28:27.062Z",
+      "date_updated": "2018-05-17T17:28:27.778Z",
+      "status": "deferred",
+      "fail_reason": null,
+      "type": "analyze",
+      "rollbacked": false,
+      "model": "transaction",
+      "model_id": "3514521",
+      "group_id": "gog_cjhat6u2e0bjf5y3tmsm589i0",
+      "next_group_id": "gog_cjhat6u280bjd5y3tiow89saw",
+      "request_id": "gr_cjhat6u1y0bjb5y3tb2bgkckg",
+      "started_at": 1526578107180,
+      "ended_at": null,
+      "processor": "antifraud",
+      "processor_response_code": null,
+      "metadata": {
+        "environment": {},
+        "kind": "rule",
+        "antifraud_analysis_id": 834113,
+        "decision_maker": "konduto"
+      }
+    },
+    {
+      "id": "go_cjhat6u2j0bjg5y3tmszihqc7",
+      "date_created": "2018-05-17T17:28:27.067Z",
+      "date_updated": "2018-05-17T17:28:27.175Z",
+      "status": "success",
+      "fail_reason": null,
+      "type": "authorize",
+      "rollbacked": false,
+      "model": "transaction",
+      "model_id": "3514521",
+      "group_id": "gog_cjhat6u2j0bjh5y3t79lbt9vb",
+      "next_group_id": "gog_cjhat6u2e0bjf5y3tmsm589i0",
+      "request_id": "gr_cjhat6u1y0bjb5y3tb2bgkckg",
+      "started_at": 1526578107083,
+      "ended_at": 1526578107175,
+      "processor": "pagarme",
+      "processor_response_code": "0000",
+      "metadata": {
+        "environment": {
+          "response_code": "0000",
+          "authorization_code": "517887",
+          "authorized_amount": 21050,
+          "tid": "3514521",
+          "nsu": "3514521"
+        }
+      }
+    },
+    {
+      "id": "go_cjhat6u650bjl5y3tfw6tixiv",
+      "date_created": "2018-05-17T17:28:27.198Z",
+      "date_updated": "2018-05-17T17:28:27.248Z",
+      "status": "success",
+      "fail_reason": null,
+      "type": "analyze",
+      "rollbacked": false,
+      "model": "transaction",
+      "model_id": "3514521",
+      "group_id": "gog_cjhat6u2e0bjf5y3tmsm589i0",
+      "next_group_id": "gog_cjhat6u280bjd5y3tiow89saw",
+      "request_id": "gr_cjhat6u1y0bjb5y3tb2bgkckg",
+      "started_at": 1526578107196,
+      "ended_at": 1526578107248,
+      "processor": "development",
+      "processor_response_code": null,
+      "metadata": {
+        "environment": {
+          "score": 19
+        },
+        "kind": "analyze",
+        "antifraud_analysis_id": 834114
+      }
+    }
+  ],
+  "chargebackOperations": [],
+  "payables": [],
+  "split_rules": [],
+  "antifraudAnalyses": [
+    {
+      "object": "antifraud_analysis",
+      "name": "pagarme",
+      "score": null,
+      "cost": 70,
+      "status": "refused",
+      "date_created": "2018-05-17T17:28:27.186Z",
+      "date_updated": "2018-05-17T17:28:27.770Z",
+      "id": 834113
+    }
+  ]
+}

--- a/packages/cockpit/src/transactions/details/result.test.js
+++ b/packages/cockpit/src/transactions/details/result.test.js
@@ -3,6 +3,8 @@ import fromRequest from './mocks/fromRequests.json'
 import expectedResult from './mocks/expectedResultMock.json'
 import fromRequestBoleto from './mocks/fromRequestsBoleto.json'
 import expectedResultBoleto from './mocks/expectedResultBoleto.json'
+import fromRequestAntifraud from './mocks/fromRequestsAntifraud.json'
+import expectedResultAntifraud from './mocks/expectedResultAntifraud.json'
 
 describe('Transaction details', () => {
   it('should work when transaction, gatewayOperations, chargebackOperations, payables, company and status are returned', () => {
@@ -11,5 +13,10 @@ describe('Transaction details', () => {
 
   it('should work when boleto has no payable', () => {
     expect(buildResult(fromRequestBoleto)).toBeJsonEqual(expectedResultBoleto)
+  })
+
+  it('should build result when pending manual review', () => {
+    expect(buildResult(fromRequestAntifraud))
+      .toBeJsonEqual(expectedResultAntifraud)
   })
 })

--- a/packages/pilot/src/models/transactionOperationTypes.js
+++ b/packages/pilot/src/models/transactionOperationTypes.js
@@ -123,19 +123,43 @@ const types = {
     status: {
       deferred: {
         color: '#41535b',
-        title: 'Análise de risco pendente',
+        title: 'Processando análise do antifraude',
       },
       failed: {
         color: '#e00403',
-        title: 'Análise de risco falhou',
+        title: 'Análise do antifraude falhou',
       },
       processing: {
         color: '#951d3c',
-        title: 'Análise de risco em processamento',
+        title: 'Processando análise do antifraude',
       },
-      success: {
+      approved: {
         color: '#4ca9d7',
-        title: 'Análise de risco aprovada',
+        title: 'Aprovada na análise do antifraude',
+      },
+      refused: {
+        color: '#e00403',
+        title: 'Recusada na análise do antifraude',
+      },
+    },
+  },
+  manual_review: {
+    status: {
+      pending: {
+        color: '#41535b',
+        title: 'Revisão pendente',
+      },
+      approved: {
+        color: '#4ca9d7',
+        title: 'Aprovada por revisão manual',
+      },
+      refused: {
+        color: '#e00403',
+        title: 'Recusada por revisão manual',
+      },
+      timeout: {
+        color: '#e00403',
+        title: 'Revisão manual expirada',
       },
     },
   },

--- a/packages/pilot/stories/pages/TransactionDetails/transactionMock.js
+++ b/packages/pilot/stories/pages/TransactionDetails/transactionMock.js
@@ -2,7 +2,7 @@
 import moment from 'moment'
 
 const transaction = {
-  "amount": 985172498,  
+  "amount": 985172498,
   "id": 3082517,
   "created_at": "2018-03-14T13:40:28.465Z",
   "updated_at": "2018-03-14T16:11:52.057Z",
@@ -73,6 +73,20 @@ const transaction = {
       "date_created": "2018-03-14T13:40:28.564Z",
       "type": "capture",
       "status": "success"
+    },
+    {
+      "created_at": "2018-03-14T13:40:28.579Z",
+      "cycle": null,
+      "id": "go_cjhat6u2e0bje5y3tcngama5p",
+      "status": "approved",
+      "type": "manual_review"
+    },
+    {
+      "created_at": "2018-03-14T13:40:28.579Z",
+      "cycle": null,
+      "id": "go_cjhat6u2e0bje5y3tcngama5q",
+      "status": "refused",
+      "type": "analyze"
     },
     {
       "id": "go_cjer4v50j5rag493sjr317z7v",


### PR DESCRIPTION
Add manual review step on transaction history as seen on the image below:

<img width="258" alt="screen shot 2018-05-17 at 11 34 50 pm" src="https://user-images.githubusercontent.com/782333/40213273-001dd638-5a2b-11e8-892c-a0aa38436f68.png">

PS: The elliptical item enumeration is related to https://github.com/pagarme/pilot/issues/627