### PR TITLE
withdraw: fix empty recipients

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -578,6 +578,7 @@
       "form_message": "Digite o valor que deseja sacar",
       "max_value_to_be": "Valor máximo a ser",
       "negative_transfer_value": "Valor solicitado é menor do que o custo",
+      "no_recipient": "Este recebedor não foi encontrado. Confira as informações e tente novamente.",
       "number": "Deve ser um número",
       "password": "Senha",
       "requested_required": "Campo obrigatório",

--- a/packages/pilot/src/pages/LoggedArea/routes.js
+++ b/packages/pilot/src/pages/LoggedArea/routes.js
@@ -47,13 +47,9 @@ export default {
   withdrawRoot: {
     component: Withdraw,
     icon: Withdraw32,
-    path: '/withdraw',
+    path: '/withdraw/:id?',
     title: 'pages.withdraw.title',
     hidden: true,
-  },
-  withdraw: {
-    hidden: true,
-    path: '/withdraw/:id?',
   },
   accountSettings: {
     title: 'pages.settings.user.menu',

--- a/packages/pilot/src/pages/Withdraw/index.js
+++ b/packages/pilot/src/pages/Withdraw/index.js
@@ -14,6 +14,8 @@ import {
   pathOr,
 } from 'ramda'
 import { translate } from 'react-i18next'
+import { Alert } from 'former-kit'
+import IconError from 'emblematic-icons/svg/ClearClose32.svg'
 import WithdrawContainer from '../../containers/Withdraw'
 import partnersBankCodes from '../../models/partnersBanksCodes'
 import env from '../../environment'
@@ -131,6 +133,7 @@ class Withdraw extends Component {
       ...defaultStepsState,
       confirmationDisabledButtons: false,
       confirmationPasswordError: '',
+      error: '',
       requested: '0',
     }
 
@@ -151,6 +154,7 @@ class Withdraw extends Component {
           id,
         },
       },
+      t,
     } = this.props
 
     let recipientPromise
@@ -164,11 +168,20 @@ class Withdraw extends Component {
     recipientPromise
       .then((recipient) => {
         this.setState({
+          error: '',
           recipient,
         })
 
         if (!id) {
           history.replace(`/withdraw/${recipient.id}`)
+        }
+      })
+      .catch(({ response }) => {
+        const { type } = response.errors[0]
+        if (type === 'not_found') {
+          this.setState({
+            error: t('pages.withdraw.no_recipient'),
+          })
         }
       })
   }
@@ -290,6 +303,7 @@ class Withdraw extends Component {
       confirmationDisabledButtons,
       confirmationPasswordError,
       currentStep,
+      error,
       recipient,
       requested,
       statusMessage,
@@ -328,6 +342,14 @@ class Withdraw extends Component {
             transferCost={transferCost}
           />
         }
+        {error &&
+          <Alert
+            icon={<IconError height={16} width={16} />}
+            type="error"
+          >
+            <span>{error}</span>
+          </Alert>
+        }
       </Fragment>
     )
   }
@@ -350,9 +372,13 @@ Withdraw.propTypes = {
       credito_em_conta: PropTypes.number,
       ted: PropTypes.number,
     }),
-  }).isRequired,
+  }),
   onWithdrawReceive: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
+}
+
+Withdraw.defaultProps = {
+  pricing: {},
 }
 
 export default enhanced(Withdraw)


### PR DESCRIPTION
Adiciona alerta quando o id de recebedor passado na url nao existe.

Nao creio que faz sentido verificar se existe ou nao recebedor padrao (ver comment do Relampago Marquin)

Closes #708 

![screenshot from 2018-06-21 16-54-23](https://user-images.githubusercontent.com/7756101/41742448-57966f10-7574-11e8-9704-d0e8a5ee6ba6.png)
