### PR TITLE
Fix sidebar redirect

### DIFF
--- a/packages/pilot/src/pages/LoggedArea/Sidebar.js
+++ b/packages/pilot/src/pages/LoggedArea/Sidebar.js
@@ -31,6 +31,7 @@ const Sidebar = ({
       .filter(({ hidden }) => !hidden)
       .map(route => ({
         ...route,
+        path: removeRouteParams(route.path),
         active: pathname.includes(removeRouteParams(route.path)),
       }))
     }


### PR DESCRIPTION
Esse PR faz com que o ultimo parametro das rotas sejam removidas ai criar os links na sidebar. Exemplo: `/withdraw/:id?` se torna `/withdraw`. Isso evita que ocorram redirects para `/withdraw/:id?`, por exemplo.

Isso tambem evita "gambiarras" como o que eh feito atualmento na definicao de rota de withdraw (eh criado duas rotas, uma hidden e outra nao). Alem disso, essa "gambiarra" feita com withdraw prejudica pois nao eh possivel pegar o parametro passado na url...

Unico problema eh se a rota tiver mais de um parametro...

O que acham?