### PR TITLE
sidebar: add summary and sections

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -478,6 +478,16 @@
       "success": "A transação foi reprocessada com sucesso",
       "title": "Reprocessar transação"
     },
+    "sidebar": {
+      "anticipation": "Antecipar",
+      "available": "Disponível",
+      "balance": "Saldo",
+      "currency_symbol": "R$",
+      "hide_balance": "Ocultar saldo",
+      "show_balance": "Mostrar saldo",
+      "waiting_funds": "A Receber",
+      "withdraw": "Sacar"
+    },
     "withdraw": {
       "balance": "Saldo disponível",
       "cancel": "Cancelar",

--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -482,6 +482,7 @@
       "anticipation": "Antecipar",
       "available": "Disponível",
       "balance": "Saldo",
+      "back_to_old_version": "Voltar para versão 1.0",
       "currency_symbol": "R$",
       "hide_balance": "Ocultar saldo",
       "show_balance": "Mostrar saldo",

--- a/packages/pilot/src/components/SidebarSections/index.js
+++ b/packages/pilot/src/components/SidebarSections/index.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button } from 'former-kit'
+
+import style from './style.css'
+
+const SidebarSections = ({
+  sections,
+}) => (
+  <div className={style.sections}>
+    <ul>
+      {sections.map(({
+        action,
+        actionTitle,
+        title,
+        value,
+      }) => (
+        <li
+          key={title}
+          className={style.item}
+        >
+          <span className={style.title}>{title}</span>
+          <div className={style.value}>{value}</div>
+          {actionTitle &&
+            <Button
+              className={style.action}
+              onClick={action}
+              size="tiny"
+            >
+              {actionTitle}
+            </Button>
+          }
+        </li>
+      ))}
+    </ul>
+  </div>
+)
+
+SidebarSections.propTypes = {
+  sections: PropTypes.arrayOf(PropTypes.shape({
+    action: PropTypes.func,
+    actionTitle: PropTypes.string,
+    title: PropTypes.string.isRequired,
+    value: PropTypes.element.isRequired,
+  })).isRequired,
+}
+
+export default SidebarSections

--- a/packages/pilot/src/components/SidebarSections/style.css
+++ b/packages/pilot/src/components/SidebarSections/style.css
@@ -1,0 +1,52 @@
+@import "former-kit-skin-pagarme/dist/styles/colors.css";
+@import "former-kit-skin-pagarme/dist/styles/spacing.css";
+
+.sections,
+.sections * {
+  box-sizing: border-box;
+}
+
+.sections {
+
+  & ul {
+    margin: 0;
+    padding: 0;
+  }
+
+  & .title {
+    color: var(--color-white);
+    display: block;
+    font-size: 14px;
+    font-weight: bold;
+    margin-top: var(--spacing-small);
+    text-transform: uppercase;
+  }
+
+  & .value {
+    color: var(--color-white);
+    font-size: 24px;
+    font-weight: bold;
+    margin-top: 4px;
+    white-space: nowrap;
+
+    & small {
+      font-size: 14px;
+    }
+  }
+
+  &:first-child .item:first-child,
+  &:first-child .item:first-child > *:first-child {
+    border: none;
+    margin: 0;
+  }
+}
+
+.item {
+  border-top: 1px solid var(--color-light-steel-200);
+  list-style: none;
+  margin-top: var(--spacing-small);
+
+  & button {
+    margin-top: var(--spacing-tiny);
+  }
+}

--- a/packages/pilot/src/components/SidebarSummary/index.js
+++ b/packages/pilot/src/components/SidebarSummary/index.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import { Spacing } from 'former-kit'
+import IconArrowDown from 'emblematic-icons/svg/ChevronDown32.svg'
+import IconArrowUp from 'emblematic-icons/svg/ChevronUp32.svg'
+
+import style from './style.css'
+
+const SidebarSummary = ({
+  children,
+  collapsed,
+  onClick,
+  subtitle,
+  title,
+}) => (
+  <div
+    className={classNames(style.summary, {
+      [style.expanded]: !collapsed,
+    })}
+  >
+    <button
+      className={style.title}
+      onClick={onClick}
+      role="link"
+    >
+      {title}
+
+      {subtitle &&
+        <span className={style.subtitle}>
+          {subtitle}
+          <Spacing size="small" />
+          {collapsed
+            ? <IconArrowDown height={16} width={16} />
+            : <IconArrowUp height={16} width={16} />
+          }
+        </span>
+      }
+    </button>
+
+    {!collapsed
+      && children
+    }
+  </div>
+)
+
+SidebarSummary.propTypes = {
+  children: PropTypes.node.isRequired,
+  collapsed: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+}
+
+export default SidebarSummary

--- a/packages/pilot/src/components/SidebarSummary/index.js
+++ b/packages/pilot/src/components/SidebarSummary/index.js
@@ -38,9 +38,7 @@ const SidebarSummary = ({
       }
     </button>
 
-    {!collapsed
-      && children
-    }
+    {!collapsed && children}
   </div>
 )
 

--- a/packages/pilot/src/components/SidebarSummary/style.css
+++ b/packages/pilot/src/components/SidebarSummary/style.css
@@ -1,0 +1,38 @@
+@import "former-kit-skin-pagarme/dist/styles/colors.css";
+@import "former-kit-skin-pagarme/dist/styles/spacing.css";
+
+.summary,
+.summary * {
+  box-sizing: border-box;
+}
+
+.summary {
+  flex-direction: column;
+  padding:
+    var(--spacing-small)
+    var(--spacing-medium);
+  width: 100%;
+
+  &.expanded {
+    background-color: #444444;
+    border-bottom: 1px dashed var(--color-light-steel-200);
+  }
+
+  & .title {
+    color: var(--color-white);
+    display: block;
+    font-size: 14px;
+    outline: none;
+    text-align: left;
+    width: 100%;
+  }
+
+  & .subtitle {
+    align-items: center;
+    color: var(--color-light-greenish-100);
+    display: flex;
+    font-size: 12px;
+    font-weight: bold;
+    padding-top: 4px;
+  }
+}

--- a/packages/pilot/src/containers/Sidebar.js
+++ b/packages/pilot/src/containers/Sidebar.js
@@ -1,9 +1,11 @@
-/* eslint-disable */
 import React from 'react'
 import PropTypes from 'prop-types'
+import { propOr, __ } from 'ramda'
 
 import {
   Button,
+  Popover,
+  PopoverContent,
   Sidebar,
   SidebarContent,
   SidebarHeader,
@@ -11,13 +13,19 @@ import {
   SidebarLinks,
 } from 'former-kit'
 
-import Menu32 from 'emblematic-icons/svg/Menu32.svg'
+import IconMenu from 'emblematic-icons/svg/Menu32.svg'
+import IconWallet from 'emblematic-icons/svg/Wallet32.svg'
+
+import SidebarSections from '../components/SidebarSections'
+import SidebarSummary from '../components/SidebarSummary'
+import formatDecimalCurrency from '../formatters/decimalCurrency'
 
 class SidebarContainer extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
       collapsed: false,
+      summaryCollapsed: true,
     }
 
     this.handleToggleSidebar = this.handleToggleSidebar.bind(this)
@@ -28,22 +36,100 @@ class SidebarContainer extends React.Component {
     this.setState({ collapsed: !collapsed })
   }
 
-  render () {
-    const { collapsed } = this.state
+  renderSections () {
     const {
+      balance,
+      onAnticipate,
+      onWithdraw,
+      t,
+    } = this.props
+
+    const getFrombalance = propOr(null, __, balance)
+    const available = getFrombalance('available')
+    const waitingFunds = getFrombalance('waitingFunds')
+
+    return (
+      <SidebarSections
+        sections={[
+          {
+            action: onWithdraw,
+            actionTitle: t('pages.sidebar.withdraw'),
+            title: t('pages.sidebar.available'),
+            value: <span><small>{t('pages.sidebar.currency_symbol')}</small> {formatDecimalCurrency(available)}</span>,
+          },
+          {
+            action: onAnticipate,
+            actionTitle: t('pages.sidebar.anticipation'),
+            title: t('pages.sidebar.waiting_funds'),
+            value: <span><small>{t('pages.sidebar.currency_symbol')}</small> {formatDecimalCurrency(waitingFunds)}</span>,
+          },
+        ]}
+      />
+    )
+  }
+
+  render () {
+    const {
+      collapsed,
+      summaryCollapsed,
+    } = this.state
+    const {
+      companyName,
       links,
       logo: Logo,
       onLinkClick,
       t,
     } = this.props
+
     return (
       <Sidebar collapsed={collapsed}>
         <SidebarHeader>
           {!collapsed && <Logo width="140" />}
-          <button onClick={this.handleToggleSidebar}>
-            <Menu32 width={16} height={16} />
-          </button>
+
+          <Button
+            onClick={this.handleToggleSidebar}
+            icon={<IconMenu width={16} height={16} />}
+            fill="clean"
+            relevance="low"
+          />
         </SidebarHeader>
+
+        {!collapsed &&
+          <SidebarSummary
+            collapsed={summaryCollapsed}
+            onClick={() => this.setState({ summaryCollapsed: !summaryCollapsed })}
+            subtitle={
+              summaryCollapsed
+                ? t('pages.sidebar.show_balance')
+                : t('pages.sidebar.hide_balance')
+            }
+            title={companyName}
+          >
+            {this.renderSections()}
+          </SidebarSummary>
+        }
+
+        {collapsed &&
+          <Popover
+            base="dark"
+            content={
+              <PopoverContent>
+                {this.renderSections()}
+              </PopoverContent>
+            }
+            placement="rightStart"
+          >
+            <SidebarLinks>
+              <SidebarLink
+                collapsed={collapsed}
+                onClick={() => null}
+                icon={<IconWallet width={16} height={16} />}
+                title={t('pages.sidebar.balance')}
+              />
+            </SidebarLinks>
+          </Popover>
+        }
+
         <SidebarLinks>
           {links.map(({
             active,
@@ -79,6 +165,11 @@ class SidebarContainer extends React.Component {
 }
 
 SidebarContainer.propTypes = {
+  balance: PropTypes.shape({
+    available: PropTypes.number,
+    waitingFunds: PropTypes.number,
+  }).isRequired,
+  companyName: PropTypes.string,
   links: PropTypes.arrayOf(PropTypes.shape({
     active: PropTypes.bool,
     title: PropTypes.string,
@@ -88,7 +179,15 @@ SidebarContainer.propTypes = {
   })).isRequired,
   logo: PropTypes.func.isRequired,
   onLinkClick: PropTypes.func.isRequired,
+  onAnticipate: PropTypes.func,
+  onWithdraw: PropTypes.func,
   t: PropTypes.func.isRequired,
+}
+
+SidebarContainer.defaultProps = {
+  companyName: '',
+  onAnticipate: null,
+  onWithdraw: null,
 }
 
 export default SidebarContainer

--- a/packages/pilot/src/containers/Sidebar.js
+++ b/packages/pilot/src/containers/Sidebar.js
@@ -155,7 +155,7 @@ class SidebarContainer extends React.Component {
               fill="outline"
               size="tiny"
             >
-              Voltar para versão 1.0
+              {t('pages.sidebar.back_to_old_version')}
             </Button>
           </SidebarContent>
         }

--- a/packages/pilot/src/pages/Account/actions/index.js
+++ b/packages/pilot/src/pages/Account/actions/index.js
@@ -20,3 +20,6 @@ export const receiveCompany = createAction(COMPANY_RECEIVE)
 
 export const LOGIN_FAIL = 'pilot/account/LOGIN_FAIL'
 export const failLogin = createAction(LOGIN_FAIL)
+
+export const RECIPIENT_BALANCE_RECEIVE = 'pilot/account/RECIPIENT_BALANCE_RECEIVE'
+export const receiveRecipientBalance = createAction(RECIPIENT_BALANCE_RECEIVE)

--- a/packages/pilot/src/pages/Account/actions/reducer.js
+++ b/packages/pilot/src/pages/Account/actions/reducer.js
@@ -1,4 +1,8 @@
-import { merge } from 'ramda'
+import {
+  applySpec,
+  merge,
+  path,
+} from 'ramda'
 
 import {
   ACCOUNT_RECEIVE,
@@ -7,7 +11,13 @@ import {
   LOGIN_RECEIVE,
   LOGIN_REQUEST,
   LOGOUT_REQUEST,
+  RECIPIENT_BALANCE_RECEIVE,
 } from '.'
+
+const getBalance = applySpec({
+  available: path(['available', 'amount']),
+  waitingFunds: path(['waiting_funds', 'amount']),
+})
 
 const initialState = {
   loading: false,
@@ -64,6 +74,15 @@ export default function loginReducer (state = initialState, action) {
 
     case LOGOUT_REQUEST: {
       return initialState
+    }
+
+    case RECIPIENT_BALANCE_RECEIVE: {
+      return merge(
+        state,
+        {
+          balance: getBalance(action.payload),
+        }
+      )
     }
 
     default:

--- a/packages/pilot/src/pages/LoggedArea/Sidebar.js
+++ b/packages/pilot/src/pages/LoggedArea/Sidebar.js
@@ -21,12 +21,16 @@ const removeRouteParams = pipe(
 )
 
 const Sidebar = ({
-  location: { pathname },
+  balance,
+  companyName,
   history,
+  location: { pathname },
+  recipientId,
   t,
 }) => (
   <SidebarContainer
-    logo={Logo}
+    balance={balance}
+    companyName={companyName}
     links={values(routes)
       .filter(({ hidden }) => !hidden)
       .map(route => ({
@@ -34,12 +38,21 @@ const Sidebar = ({
         active: pathname.includes(removeRouteParams(route.path)),
       }))
     }
+    logo={Logo}
+    onAnticipate={() => history.push(`/anticipation/${recipientId}`)}
     onLinkClick={history.push}
+    onWithdraw={() => history.push(`/withdraw/${recipientId}`)}
     t={t}
   />
 )
 
 Sidebar.propTypes = {
+  balance: PropTypes.shape({
+    available: PropTypes.number,
+    waitingFunds: PropTypes.number,
+  }).isRequired,
+  companyName: PropTypes.string,
+  recipientId: PropTypes.string,
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }).isRequired,
@@ -47,6 +60,11 @@ Sidebar.propTypes = {
     push: PropTypes.func,
   }).isRequired,
   t: PropTypes.func.isRequired,
+}
+
+Sidebar.defaultProps = {
+  companyName: '',
+  recipientId: null,
 }
 
 export default withRouter(Sidebar)

--- a/packages/pilot/src/pages/LoggedArea/index.js
+++ b/packages/pilot/src/pages/LoggedArea/index.js
@@ -6,30 +6,59 @@ import {
   Switch,
   withRouter,
 } from 'react-router-dom'
+import { connect } from 'react-redux'
 import { translate } from 'react-i18next'
-import { compose } from 'ramda'
+import {
+  applySpec,
+  compose,
+  path,
+} from 'ramda'
 import { Layout } from 'former-kit'
+import env from '../../environment'
 
 import Sidebar from './Sidebar'
 import Header from './Header'
 
 import routes from './routes'
 
+const getRecipientId = path(['account', 'company', 'default_recipient_id', env])
+const getBalance = path(['account', 'balance'])
+const getCompanyName = path(['account', 'company', 'name'])
+
+const mapStateToProps = applySpec({
+  balance: getBalance,
+  companyName: getCompanyName,
+  recipientId: getRecipientId,
+})
+
 const enhanced = compose(
   translate(),
-  withRouter
+  withRouter,
+  connect(mapStateToProps)
 )
 
-const LoggedArea = ({ t }) => (
+const LoggedArea = ({
+  balance,
+  companyName,
+  recipientId,
+  t,
+}) => (
   <Layout
-    sidebar={<Sidebar t={t} />}
+    sidebar={
+      <Sidebar
+        companyName={companyName}
+        balance={balance}
+        recipientId={recipientId}
+        t={t}
+      />
+    }
     header={<Header t={t} />}
   >
     <Switch>
-      {Object.values(routes).map(({ component, path }) => (
+      {Object.values(routes).map(({ component, path: pathURI }) => (
         <Route
-          key={path}
-          path={path}
+          key={pathURI}
+          path={pathURI}
           component={component}
         />
       ))}
@@ -39,7 +68,19 @@ const LoggedArea = ({ t }) => (
 )
 
 LoggedArea.propTypes = {
+  balance: PropTypes.shape({
+    available: PropTypes.number,
+    waitingFunds: PropTypes.number,
+  }),
+  companyName: PropTypes.string,
+  recipientId: PropTypes.string,
   t: PropTypes.func.isRequired,
+}
+
+LoggedArea.defaultProps = {
+  balance: {},
+  companyName: '',
+  recipientId: null,
 }
 
 export default enhanced(LoggedArea)

--- a/packages/pilot/src/pages/LoggedArea/routes.js
+++ b/packages/pilot/src/pages/LoggedArea/routes.js
@@ -35,6 +35,7 @@ export default {
     icon: Withdraw32,
     path: '/withdraw',
     title: 'pages.withdraw.title',
+    hidden: true,
   },
   withdraw: {
     hidden: true,

--- a/packages/pilot/src/pages/Withdraw/actions/index.js
+++ b/packages/pilot/src/pages/Withdraw/actions/index.js
@@ -1,0 +1,4 @@
+import { createAction } from 'redux-actions'
+
+export const WITHDRAW_RECEIVE = 'pilot/withdraw/WITHDRAW_RECEIVE'
+export const receiveWithdraw = createAction(WITHDRAW_RECEIVE)

--- a/packages/pilot/src/pages/Withdraw/index.js
+++ b/packages/pilot/src/pages/Withdraw/index.js
@@ -18,6 +18,8 @@ import WithdrawContainer from '../../containers/Withdraw'
 import partnersBankCodes from '../../models/partnersBanksCodes'
 import env from '../../environment'
 
+import { receiveWithdraw } from './actions/'
+
 const mapStateToProps = ({
   account: {
     client,
@@ -30,9 +32,16 @@ const mapStateToProps = ({
   pricing,
 })
 
+const mapDispatchToProps = ({
+  onWithdrawReceive: receiveWithdraw,
+})
+
 const enhanced = compose(
   translate('translations'),
-  connect(mapStateToProps),
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
   withRouter
 )
 
@@ -186,6 +195,7 @@ class Withdraw extends Component {
     const {
       client,
       t,
+      onWithdrawReceive,
     } = this.props
 
     const {
@@ -204,6 +214,8 @@ class Withdraw extends Component {
           statusMessage: t('pages.withdraw.withdraw_success'),
           stepsStatus: getStepsStatus('result', 'success'),
         })
+
+        onWithdrawReceive()
       })
       .catch(() => {
         this.setState({
@@ -339,6 +351,7 @@ Withdraw.propTypes = {
       ted: PropTypes.number,
     }),
   }).isRequired,
+  onWithdrawReceive: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
 }
 

--- a/packages/pilot/stories/components/SidebarSections/index.js
+++ b/packages/pilot/stories/components/SidebarSections/index.js
@@ -1,0 +1,33 @@
+import React from 'react'
+
+import { action } from '@storybook/addon-actions'
+
+import Section from '../../Section'
+import SidebarSections from '../../../src/components/SidebarSections'
+
+const sections = {
+  data: [
+    {
+      action: action('clicked'),
+      actionTitle: 'Sacar',
+      title: 'Disponível',
+      value: <span><small>R$</small> 15.000,00</span>,
+    },
+    {
+      action: action('clicked'),
+      actionTitle: 'Antecipar',
+      title: 'A receber',
+      value: <span><small>R$</small> 70.000,00</span>,
+    },
+  ],
+}
+
+const SidebarSectionsExample = () => (
+  <Section title="With base dark">
+    <div style={{ backgroundColor: '#444444' }}>
+      <SidebarSections sections={sections.data} />
+    </div>
+  </Section>
+)
+
+export default SidebarSectionsExample

--- a/packages/pilot/stories/components/SidebarSummary/index.js
+++ b/packages/pilot/stories/components/SidebarSummary/index.js
@@ -1,0 +1,68 @@
+import React from 'react'
+
+import { action } from '@storybook/addon-actions'
+
+import Section from '../../Section'
+import SidebarSections from '../../../src/components/SidebarSections'
+import SidebarSummary from '../../../src/components/SidebarSummary'
+
+const sections = {
+  data: [
+    {
+      action: action('clicked'),
+      actionTitle: 'Sacar',
+      title: 'Disponível',
+      value: <span><small>R$</small> 15.000,00</span>,
+    },
+    {
+      action: action('clicked'),
+      actionTitle: 'Antecipar',
+      title: 'A receber',
+      value: <span><small>R$</small> 70.000,00</span>,
+    },
+  ],
+  hideMsg: 'Ocultar saldo',
+  showMsg: 'Mostrar saldo',
+  title: 'Pagar.me',
+}
+
+class SidebarSummaryExample extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      collapsed: false,
+      summaryCollapsed: true,
+    }
+  }
+
+  render () {
+    const {
+      collapsed,
+      summaryCollapsed,
+    } = this.state
+
+    return (
+      <Section title="With base dark">
+        <div style={{ backgroundColor: '#383838' }}>
+          {!collapsed &&
+            <SidebarSummary
+              collapsed={summaryCollapsed}
+              onClick={() => this.setState({ summaryCollapsed: !summaryCollapsed })}
+              subtitle={
+                summaryCollapsed
+                  ? `${sections.showMsg}`
+                  : `${sections.hideMsg}`
+              }
+              title={sections.title}
+            >
+              <SidebarSections sections={sections.data} />
+            </SidebarSummary>
+          }
+        </div>
+      </Section>
+    )
+  }
+}
+
+export default SidebarSummaryExample

--- a/packages/pilot/stories/components/index.js
+++ b/packages/pilot/stories/components/index.js
@@ -22,6 +22,8 @@ import ApiKeySection from './ApiKey'
 import PendingRequests from './PendingRequests'
 import BalanceTotalDisplay from './BalanceTotalDisplay'
 import BalanceSummary from './BalanceSummary'
+import SidebarSections from './SidebarSections'
+import SidebarSummary from './SidebarSummary'
 
 storiesOf('Components', module)
   .add('Copy button', () => (
@@ -86,4 +88,10 @@ storiesOf('Components', module)
   ))
   .add('Balance summary', () => (
     <BalanceSummary />
+  ))
+  .add('Sidebar Sections', () => (
+    <SidebarSections />
+  ))
+  .add('Sidebar Summary', () => (
+    <SidebarSummary />
   ))


### PR DESCRIPTION
- Add `SidebarSummary`
- Add `SidebarSections`
- Add epic to update Sidebar Values when a withdraw is done
- Refactor sidebar to add the new components
- Add `back to the version 1.0` translation
- Resolves https://github.com/pagarme/pilot/issues/730