### PR TITLE
recipient: add bank account step

### DIFF
--- a/packages/pilot/src/containers/AddRecipient/BankAccountStep/AddAccount/index.js
+++ b/packages/pilot/src/containers/AddRecipient/BankAccountStep/AddAccount/index.js
@@ -1,0 +1,147 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Form from 'react-vanilla-form'
+
+import {
+  Button,
+  CardActions,
+  CardContent,
+  Col,
+  FormDropdown,
+  FormInput,
+  Grid,
+  Row,
+  Spacing,
+} from 'former-kit'
+
+import { isEmpty } from 'ramda'
+
+import accountTypes from '../../../../models/accountTypes'
+import createNumberValidation from '../../../../validation/number'
+import createRequiredValidation from '../../../../validation/required'
+import style from '../style.css'
+
+const AddAccount = ({
+  onBack,
+  onCancel,
+  onContinue,
+  t,
+}) => {
+  const required = createRequiredValidation(t('requiredMessage'))
+  const number = createNumberValidation(t('numberMessage'))
+
+  const accountTypeOptions = accountTypes.map(accountType => ({
+    name: t(`models.account_type.${accountType}`),
+    value: accountType,
+  }))
+
+  return (
+    <Form
+      data={{
+        account_name: '',
+        account_number: '',
+        account_type: accountTypeOptions[0].value,
+        agency: '',
+        bank: '',
+      }}
+      validateOn="blur"
+      validation={{
+        account_name: [required],
+        account_number: [required, number],
+        account_type: [required],
+        agency: [required, number],
+        bank: [required],
+      }}
+      onSubmit={(formData, formErrors = {}) => {
+        if (isEmpty(formErrors)) onContinue(formData)
+      }}
+    >
+      <CardContent>
+        <Grid>
+          <Row>
+            <Col tv={2} desk={2} tablet={4} palm={4}>
+              <FormInput
+                type="text"
+                label={t('bankLabel')}
+                name="bank"
+                placeholder={t('bankPlaceholder')}
+              />
+            </Col>
+          </Row>
+          <Row>
+            <Col tv={3} desk={3} tablet={6} palm={6}>
+              <FormInput
+                type="text"
+                label={t('agencyLabel')}
+                name="agency"
+                placeholder={t('agencyPlaceholder')}
+              />
+            </Col>
+            <Col tv={3} desk={3} tablet={4} palm={4}>
+              <FormInput
+                type="text"
+                label={t('accountNumberLabel')}
+                name="account_number"
+                placeholder={t('accountNumberPlaceholder')}
+              />
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              <label htmlFor="account_type">{t('accountTypeLabel')}</label>
+              <FormDropdown
+                name="account_type"
+                title={t('accountTypeLabel')}
+                options={accountTypeOptions}
+              />
+            </Col>
+          </Row>
+          <Row>
+            <Col tv={3} desk={3} tablet={6} palm={6}>
+              <FormInput
+                type="text"
+                label={t('accountNameLabel')}
+                name="account_name"
+                placeholder={t('accountNamePlaceholder')}
+              />
+            </Col>
+          </Row>
+        </Grid>
+      </CardContent>
+      <div className={style.paddingTop}>
+        <CardActions>
+          <Button
+            type="button"
+            onClick={onCancel}
+            relevance="low"
+            fill="outline"
+          >
+            {t('cancelText')}
+          </Button>
+          <Spacing />
+          <Button
+            type="button"
+            onClick={onBack}
+            fill="outline"
+          >
+            {t('backText')}
+          </Button>
+          <Button
+            type="submit"
+          >
+            {t('continueText')}
+          </Button>
+        </CardActions>
+      </div>
+    </Form>
+  )
+}
+
+AddAccount.propTypes = {
+  onContinue: PropTypes.func.isRequired,
+  onBack: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired,
+}
+
+export default AddAccount

--- a/packages/pilot/src/containers/AddRecipient/BankAccountStep/SelectAccount/index.js
+++ b/packages/pilot/src/containers/AddRecipient/BankAccountStep/SelectAccount/index.js
@@ -1,0 +1,96 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Form from 'react-vanilla-form'
+
+import {
+  Button,
+  CardActions,
+  CardContent,
+  Col,
+  FormDropdown,
+  Grid,
+  Row,
+  Spacing,
+} from 'former-kit'
+
+import style from '../style.css'
+
+const toDropdownOptions = ({ name, id }) => ({ name, value: id })
+
+const SelectAccount = ({
+  accounts,
+  onBack,
+  onCancel,
+  onContinue,
+  t,
+}) => {
+  const options = accounts.map(toDropdownOptions)
+
+  return (
+    <Form
+      onSubmit={onContinue}
+      data={{
+        account_id: options[0].value,
+      }}
+    >
+      <CardContent>
+        <Grid>
+          <Row>
+            <Col>
+              <label htmlFor="account_id">{t('selectAccountLabel')}</label>
+              <FormDropdown
+                name="account_id"
+                title={t('selectAccountLabel')}
+                options={options}
+              />
+            </Col>
+          </Row>
+        </Grid>
+      </CardContent>
+      <div className={style.paddingTop}>
+        <CardActions>
+          <Button
+            type="button"
+            onClick={onCancel}
+            relevance="low"
+            fill="outline"
+          >
+            {t('cancelText')}
+          </Button>
+          <Spacing />
+          <Button
+            type="button"
+            onClick={onBack}
+            fill="outline"
+          >
+            {t('backText')}
+          </Button>
+          <Button
+            type="submit"
+          >
+            {t('continueText')}
+          </Button>
+        </CardActions>
+      </div>
+    </Form>
+  )
+}
+
+SelectAccount.propTypes = {
+  accounts: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ),
+  onBack: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onContinue: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired,
+}
+
+SelectAccount.defaultProps = {
+  accounts: [],
+}
+
+export default SelectAccount

--- a/packages/pilot/src/containers/AddRecipient/BankAccountStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/BankAccountStep/index.js
@@ -1,0 +1,103 @@
+import React, { Component, Fragment } from 'react'
+import PropTypes from 'prop-types'
+import { SegmentedSwitch, CardContent } from 'former-kit'
+
+import {
+  complement,
+  either,
+  isEmpty,
+  isNil,
+} from 'ramda'
+
+import AddAccount from './AddAccount'
+import SelectAccount from './SelectAccount'
+
+const hasItems = complement(either(isEmpty, isNil))
+
+const ADD_ACCOUNT = 'addAccount'
+const SELECT_ACCOUNT = 'selectAccount'
+
+export default class BankAccountStep extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      selectedForm: SELECT_ACCOUNT,
+    }
+
+    this.handleFormSelectionChange = this.handleFormSelectionChange.bind(this)
+  }
+
+  handleFormSelectionChange (selectedForm) {
+    this.setState({ selectedForm })
+  }
+
+  renderSelectedForm () {
+    const { selectedForm } = this.state
+
+    if (selectedForm === ADD_ACCOUNT) {
+      return <AddAccount {...this.props} />
+    }
+
+    return <SelectAccount {...this.props} />
+  }
+
+  render () {
+    const { t, accounts } = this.props
+    const displaySelectAccount = hasItems(accounts)
+
+    if (displaySelectAccount) {
+      return (
+        <Fragment>
+          <CardContent>
+            <strong>{t('bankAccountLabel')}</strong>
+            <p>{t('addOrSelectAccount')}</p>
+            <SegmentedSwitch
+              options={[
+                {
+                  title: t('selectAccountOption'),
+                  value: SELECT_ACCOUNT,
+                },
+                {
+                  title: t('addAccountOption'),
+                  value: ADD_ACCOUNT,
+                },
+              ]}
+              onChange={this.handleFormSelectionChange}
+              name="select_form"
+              value={this.state.selectedForm}
+            />
+          </CardContent>
+          { this.renderSelectedForm() }
+        </Fragment>
+      )
+    }
+
+    return (
+      <Fragment>
+        <CardContent>
+          <strong>{t('bankAccountLabel')}</strong>
+          <p>{t('addNewAccount')}</p>
+        </CardContent>
+        <AddAccount {...this.props} />
+      </Fragment>
+    )
+  }
+}
+
+BankAccountStep.propTypes = {
+  accounts: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ),
+  onContinue: PropTypes.func.isRequired,
+  onBack: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired,
+}
+
+BankAccountStep.defaultProps = {
+  accounts: [],
+}

--- a/packages/pilot/src/containers/AddRecipient/BankAccountStep/style.css
+++ b/packages/pilot/src/containers/AddRecipient/BankAccountStep/style.css
@@ -1,0 +1,5 @@
+@import "former-kit-skin-pagarme/dist/styles/spacing.css";
+
+.paddingTop {
+  padding-top: var(--spacing-small);
+}

--- a/packages/pilot/stories/containers/AddRecipient/BankAccountStep/AddAccount/index.js
+++ b/packages/pilot/stories/containers/AddRecipient/BankAccountStep/AddAccount/index.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { Card } from 'former-kit'
+
+import Section from '../../../../Section'
+import AddAccount from '../../../../../src/containers/AddRecipient/BankAccountStep/AddAccount'
+
+const AddAccountExample = () => (
+  <Section>
+    <Card>
+      <AddAccount
+        onContinue={action('Continue')}
+        onBack={action('Back')}
+        onCancel={action('Cancel')}
+        t={t => t}
+      />
+    </Card>
+  </Section>
+)
+
+export default AddAccountExample

--- a/packages/pilot/stories/containers/AddRecipient/BankAccountStep/SelectAccount/index.js
+++ b/packages/pilot/stories/containers/AddRecipient/BankAccountStep/SelectAccount/index.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { Card } from 'former-kit'
+
+import Section from '../../../../Section'
+import SelectAccount from '../../../../../src/containers/AddRecipient/BankAccountStep/SelectAccount'
+
+const exampleAccounts = [
+  {
+    name: 'First account',
+    id: '1',
+  },
+  {
+    name: 'Second account',
+    id: '2',
+  },
+]
+
+const SelectAccountExample = () => (
+  <Section>
+    <Card>
+      <SelectAccount
+        accounts={exampleAccounts}
+        onContinue={action('Continue')}
+        onBack={action('Back')}
+        onCancel={action('Cancel')}
+        t={t => t}
+      />
+    </Card>
+  </Section>
+)
+
+export default SelectAccountExample

--- a/packages/pilot/stories/containers/AddRecipient/BankAccountStep/index.js
+++ b/packages/pilot/stories/containers/AddRecipient/BankAccountStep/index.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { Card } from 'former-kit'
+
+import Section from '../../../Section'
+import BankAccountStep from '../../../../src/containers/AddRecipient/BankAccountStep'
+
+const exampleAccounts = [
+  {
+    name: 'First account',
+    id: '1',
+  },
+  {
+    name: 'Second account',
+    id: '2',
+  },
+]
+
+const AddAccountExample = () => (
+  <Section>
+    <Card>
+      <BankAccountStep
+        onContinue={action('Continue')}
+        onBack={action('Back')}
+        onCancel={action('Cancel')}
+        t={t => t}
+        accounts={exampleAccounts}
+      />
+    </Card>
+  </Section>
+)
+
+export default AddAccountExample

--- a/packages/pilot/stories/containers/index.js
+++ b/packages/pilot/stories/containers/index.js
@@ -61,6 +61,9 @@ storiesOf('Containers', module)
   .add('Add Account', () => (
     <AddAccount />
   ))
+  .add('Bank Account Step', () => (
+    <BankAccountStep />
+  ))
   .add('Recipient list', () => (
     <RecipientListState />
   ))

--- a/packages/pilot/stories/containers/index.js
+++ b/packages/pilot/stories/containers/index.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 
 import AnticipationForm from './Anticipation/Form'
+import AddAccount from './AddRecipient/BankAccountStep/AddAccount'
+import BankAccountStep from './AddRecipient/BankAccountStep'
 import BoletoForm from './Refund/BoletoForm'
 import BoletoRefundConfirm from './Refund/BoletoConfirmation'
 import BoletoRefundResult from './Refund/BoletoResult'
@@ -55,6 +57,9 @@ import Anticipation from './Anticipation'
 storiesOf('Containers', module)
   .add('Anticipation Form', () => (
     <AnticipationForm />
+  ))
+  .add('Add Account', () => (
+    <AddAccount />
   ))
   .add('Recipient list', () => (
     <RecipientListState />

--- a/packages/pilot/stories/containers/index.js
+++ b/packages/pilot/stories/containers/index.js
@@ -33,6 +33,7 @@ import {
 import Reprocess from './Reprocess'
 import ReprocessForm from './Reprocess/Form'
 import ReprocessResult from './Reprocess/Result'
+import SelectAccount from './AddRecipient/BankAccountStep/SelectAccount'
 import Withdraw from './Withdraw'
 import WithdrawConfirmation from './Withdraw/Confirmation'
 import WithdrawForm from './Withdraw/Form'
@@ -147,6 +148,9 @@ storiesOf('Containers', module)
         result: 'error',
       }}
     />
+  ))
+  .add('Select Account', () => (
+    <SelectAccount />
   ))
   .add('Withdraw', () => (
     <Withdraw />


### PR DESCRIPTION
### Contêiner do Passo de Conta Bancária

Adiciona o passo de selecionar/cadastrar uma conta bancária, para o fluxo de cadastrar um novo recebedor na página de recebedores.

![screenshot_2018-07-30 zeplin - project](https://user-images.githubusercontent.com/28565117/43400136-3c665d12-93e3-11e8-9351-f09dd9090075.png)

![screenshot_2018-07-30 zeplin - project-2](https://user-images.githubusercontent.com/28565117/43400141-3fac9c16-93e3-11e8-99bb-342f63662619.png)

#### Observações
- Se o recebedor não tiver nenhuma conta cadastrada, o dropdown junto com o switch não devem ser renderizados, mostrando apenas a opção de "adicionar uma conta".

#### Sub tarefas
- [X] Contêiner de selecionar uma conta
- [X] Contêiner de adicionar uma conta
