### PR TITLE
validation: fix require validation

### DIFF
--- a/packages/pilot/src/validation/required.js
+++ b/packages/pilot/src/validation/required.js
@@ -1,1 +1,9 @@
-export default message => value => !value && message
+import {
+  either,
+  isEmpty,
+  isNil,
+} from 'ramda'
+
+const isNilOrEmpty = either(isEmpty, isNil)
+
+export default message => value => isNilOrEmpty(value) && message


### PR DESCRIPTION
A validação de `require` não atendia a todos os cenários que precisamos

### Errors
| Case        | Old            | Fixed         |
| ------------- | ---------------| -------------- |
| []               | `false`        | `message` |
| {}               | `false`        | `message` |
| ``               | `message` | `message` |
| null            | `message` | `message` |
| undefined  | `message` | `message` |

### Sucessos
| Case        | Old            | Fixed         |
| ------------- | ---------------| -------------- |
| 0              | `message` | `false`        |
| [1]            | `false`        | `false`        |
| {a: 0}        | `false`        | `false`       |
| true          | `false`        | `false`       |
| false         | `message` | `false`       |
