### PR TITLE
circle-ci: add yarn lint to packages/pilot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
 
       - run: |
           cd packages/pilot
+          yarn lint
           yarn build
           yarn build-storybook
           yarn percy; true


### PR DESCRIPTION
- Add `yarn lint` to packages/pilot 'cause there are CSS and JS errors passing on CircleCI.