### PR TITLE
recipient-detail-info: add component

### DIFF
--- a/packages/pilot/src/containers/RecipientDetailInfo/index.js
+++ b/packages/pilot/src/containers/RecipientDetailInfo/index.js
@@ -1,0 +1,181 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import Tree from 'react-json-tree'
+import {
+  CardContent,
+  CardSection,
+  CardTitle,
+} from 'former-kit'
+import { pick } from 'ramda'
+import PartnerInfo from '../AddRecipient/ConfirmStep/PartnerInfo'
+import ReceiverInfo from '../AddRecipient/ConfirmStep/ReceiverInfo'
+import styles from './style.css'
+
+const RecipientDetailInfo = ({
+  identification,
+  bankAccount,
+  configuration,
+  t,
+}) => (
+  <Fragment>
+    <CardContent>
+      <CardSection>
+        <CardTitle className={styles.title} title={t('dados_cadastrais_do_recebedor')} />
+        <CardContent>
+          <ReceiverInfo
+            identification={pick([
+              'cnpj',
+              'cnpjEmail',
+              'cnpjInformation',
+              'cnpjName',
+              'cnpjPhone',
+              'cnpjUrl',
+              'cpf',
+              'cpfEmail',
+              'cpfInformation',
+              'cpfName',
+              'cpfPhone',
+              'cpfUrl',
+              'documentType',
+            ], identification)}
+            t={t}
+          />
+        </CardContent>
+      </CardSection>
+    </CardContent>
+    <CardContent>
+      <CardSection>
+        <CardTitle className={styles.title} title={t('dados_cadastrais_dos_socios')} />
+        <CardContent>
+          <PartnerInfo
+            identification={pick([
+              'partnerNumber',
+              'partner0',
+              'partner1',
+              'partner2',
+              'partner3',
+              'partner4',
+            ], identification)}
+            t={t}
+          />
+        </CardContent>
+      </CardSection>
+    </CardContent>
+    <CardContent>
+      <CardSection>
+        <CardTitle className={styles.title} title={t('metadata')} />
+        <CardContent>
+          <Tree
+            data={{
+              identification,
+              bankAccount,
+              configuration,
+            }}
+            theme={{
+              arrowSign: () => ({ className: styles.arrow }),
+              tree: () => ({ className: styles.tree }),
+              valueText: () => ({ className: styles.value }),
+            }}
+            getItemString={() => null}
+            hideRoot
+          />
+        </CardContent>
+      </CardSection>
+    </CardContent>
+  </Fragment>
+)
+
+const partnerPropTypes = PropTypes.shape({
+  cpf: PropTypes.string,
+  name: PropTypes.string,
+  phone: PropTypes.string,
+})
+
+const partnerDefaultTypes = {
+  cpf: '',
+  name: '',
+  phone: '',
+}
+
+RecipientDetailInfo.propTypes = {
+  bankAccount: PropTypes.shape({
+    account_name: PropTypes.string,
+    account_number: PropTypes.string,
+    account_type: PropTypes.string,
+    agency: PropTypes.string,
+    bank: PropTypes.string,
+  }),
+  configuration: PropTypes.shape({
+    anticipationDays: PropTypes.string,
+    anticipationModel: PropTypes.string,
+    anticipationVolumePercentage: PropTypes.string,
+    transferDay: PropTypes.string,
+    transferEnabled: PropTypes.bool,
+    transferInterval: PropTypes.string,
+    transferWeekday: PropTypes.string,
+  }),
+  identification: PropTypes.shape({
+    cnpj: PropTypes.string,
+    cnpjEmail: PropTypes.string,
+    cnpjInformation: PropTypes.bool,
+    cnpjName: PropTypes.string,
+    cnpjPhone: PropTypes.string,
+    cnpjUrl: PropTypes.string,
+    cpf: PropTypes.string,
+    cpfEmail: PropTypes.string,
+    cpfInformation: PropTypes.bool,
+    cpfName: PropTypes.string,
+    cpfPhone: PropTypes.string,
+    cpfUrl: PropTypes.string,
+    documentType: PropTypes.string,
+    partner0: partnerPropTypes,
+    partner1: partnerPropTypes,
+    partner2: partnerPropTypes,
+    partner3: partnerPropTypes,
+    partner4: partnerPropTypes,
+    partnerNumber: PropTypes.string,
+  }),
+  t: PropTypes.func.isRequired,
+}
+
+RecipientDetailInfo.defaultProps = {
+  identification: {
+    cnpj: '',
+    cnpjEmail: '',
+    cnpjInformation: false,
+    cnpjName: '',
+    cnpjPhone: '',
+    cnpjUrl: '',
+    cpf: '',
+    cpfEmail: '',
+    cpfInformation: false,
+    cpfName: '',
+    cpfPhone: '',
+    cpfUrl: '',
+    documentType: '',
+    partnerNumber: '',
+    partner0: partnerDefaultTypes,
+    partner1: partnerDefaultTypes,
+    partner2: partnerDefaultTypes,
+    partner3: partnerDefaultTypes,
+    partner4: partnerDefaultTypes,
+  },
+  configuration: {
+    anticipationModel: '',
+    anticipationVolumePercentage: '',
+    anticipationDays: '',
+    transferEnabled: false,
+    transferInterval: '',
+    transferDay: '',
+    transferWeekday: '',
+  },
+  bankAccount: {
+    account_name: '',
+    account_number: '',
+    account_type: '',
+    agency: '',
+    bank: '',
+  },
+}
+
+export default RecipientDetailInfo

--- a/packages/pilot/src/containers/RecipientDetailInfo/style.css
+++ b/packages/pilot/src/containers/RecipientDetailInfo/style.css
@@ -1,0 +1,43 @@
+@import "former-kit-skin-pagarme/dist/styles/spacing.css";
+@import "former-kit-skin-pagarme/dist/styles/colors.css";
+
+.title {
+  color: var(--color-light-steel-100);
+  display: inline-flex;
+}
+
+.list {
+  font-size: 11px;
+}
+
+.textList {
+  color: var(--color-light-steel-100);
+  font-size: 14px;
+}
+
+.tree {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  user-select: none;
+
+  & * {
+    user-select: none;
+    font-size: 14px;
+    color: var(--color-light-steel-100);
+  }
+
+  & li {
+    margin-top: var(--spacing-small);
+    margin-bottom: var(--spacing-small);
+    list-style: none;
+  }
+}
+
+.value {
+  color: var(--color-light-steel-100);
+}
+
+.arrow {
+  color: var(--color-light-steel-100);
+}

--- a/packages/pilot/stories/containers/RecipientDetailInfo/index.js
+++ b/packages/pilot/stories/containers/RecipientDetailInfo/index.js
@@ -1,0 +1,80 @@
+import React from 'react'
+import { Card } from 'former-kit'
+
+import Section from '../../Section'
+import RecipientDetailInfo from '../../../src/containers/RecipientDetailInfo'
+
+const identification = {
+  cnpj: '11.111.111/1111-11',
+  cnpjEmail: 'star@wars.com',
+  cnpjInformation: true,
+  cnpjName: 'Star Wars Ltda',
+  cnpjPhone: '21 2222-2222',
+  cnpjUrl: 'http://www.starwars.com',
+  cpf: '111-111-111-11',
+  cpfEmail: 'barroso@barroso.com',
+  cpfInformation: false,
+  cpfName: 'Guilherme Melo Barroso',
+  cpfPhone: '21 99999-9999',
+  cpfUrl: 'www.cpfUrl.com.br',
+  documentType: 'cnpj',
+  partnerNumber: '4',
+  partner0: {
+    cpf: '222.222.222-22',
+    name: 'Luke Skywalker',
+    phone: '21 99999-9999',
+  },
+  partner1: {
+    cpf: '111.111.111-11',
+    name: 'Han Solo',
+    phone: '21 99999-9999',
+  },
+  partner2: {
+    cpf: '333.333.333-33',
+    name: 'Princess Leia',
+    phone: '11 88888-8888',
+  },
+  partner3: {
+    cpf: '444.444.444-44',
+    name: 'Chewie',
+    phone: '11 77777-7777',
+  },
+  partner4: {
+    cpf: '',
+    name: '',
+    phone: '',
+  },
+}
+
+const configuration = {
+  anticipationModel: 'Automática por volume',
+  anticipationVolumePercentage: '50',
+  anticipationDays: '',
+  transferEnabled: true,
+  transferInterval: 'Mensal',
+  transferDay: '15',
+  transferWeekday: 'Terça-feira',
+}
+
+const bankAccount = {
+  account_name: 'Conta Bancária',
+  account_number: '11111-1',
+  account_type: 'Conta-corrente',
+  agency: '1111',
+  bank: '351 - Itaú Unibanco SA',
+}
+
+const RecipientDetailExample = () => (
+  <Section>
+    <Card>
+      <RecipientDetailInfo
+        identification={identification}
+        configuration={configuration}
+        bankAccount={bankAccount}
+        t={t => t}
+      />
+    </Card>
+  </Section>
+)
+
+export default RecipientDetailExample

--- a/packages/pilot/stories/containers/index.js
+++ b/packages/pilot/stories/containers/index.js
@@ -59,8 +59,12 @@ import Anticipation from './Anticipation'
 import ConclusionStepSuccess from './AddRecipient/ConclusionStep/Success'
 import ConclusionStepFail from './AddRecipient/ConclusionStep/Fail'
 import ConfigurationStep from './AddRecipient/ConfigurationsStep'
+import RecipientDetailInfo from './RecipientDetailInfo'
 
 storiesOf('Containers', module)
+  .add('Recipient Detail Info', () => (
+    <RecipientDetailInfo />
+  ))
   .add('Recipient Conclusion Success', () => (
     <ConclusionStepSuccess />
   ))


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
Renderiza a terceira aba de `Mais Informações` da página de `Detalhes de Recebedores`

## Checklist
- [x] Adiciona um aba a mais na página `Detalhes de Recebedores`
- [x] Reaproveita o component `ReceiverInfo` de `ConfirmStep`
- [x] Reaproveita o component `PartnerInfo` de `ConfirmStep`

## Issues linkadas
- [Issue 264](https://github.com/pagarme/caesar/issues/264) 

## Screenshots
![image](https://user-images.githubusercontent.com/20197808/44684369-4dc0f700-aa1f-11e8-8b22-4da27e5f6268.png)

### Layout:
- [Zeplin](https://app.zeplin.io/project/59e66a0aa633e7a9cf5c0cf4/screen/5b69e3371f63306dac625f50)
