### PR TITLE
Update react-vanilla-form to 0.6.1

### DIFF
--- a/packages/pilot/package.json
+++ b/packages/pilot/package.json
@@ -30,7 +30,7 @@
     "react-router-dom": "4.2.2",
     "react-scripts-former-kit-dashboard": "0.1.1",
     "react-textfit": "1.1.0",
-    "react-vanilla-form": "0.6.0",
+    "react-vanilla-form": "0.6.1",
     "recharts": "1.0.0-beta.10",
     "redux": "3.7.2",
     "redux-actions": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9684,9 +9684,9 @@ react-treebeard@^2.1.0:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react-vanilla-form@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/react-vanilla-form/-/react-vanilla-form-0.6.0.tgz#6ae86110a822b010b021d8986eaaa4b42a67a221"
+react-vanilla-form@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/react-vanilla-form/-/react-vanilla-form-0.6.1.tgz#3b46adc0ce729137b7a1ed3f089591c86ef0a39d"
   dependencies:
     ramda "0.25.0"
 


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->
Bump `react-vanilla-form` to version 0.6.1
