### PR TITLE
Extrato do Recebedor

### DIFF
--- a/packages/pilot/src/components/BalanceSummary/index.js
+++ b/packages/pilot/src/components/BalanceSummary/index.js
@@ -2,10 +2,6 @@ import React from 'react'
 import moment from 'moment'
 import PropTypes from 'prop-types'
 import { keys } from 'ramda'
-import {
-  CardContent,
-  CardSection,
-} from 'former-kit'
 import IconForward from 'emblematic-icons/svg/ArrowForward24.svg'
 
 import TotalDisplay from '../TotalDisplay'
@@ -29,29 +25,25 @@ const colors = {
 }
 
 const BalanceSummary = ({ amount, dates }) => (
-  <CardSection>
-    <CardContent>
-      <div className={style.content}>
-        <div className={style.dates}>
-          { renderDate(dates.start) }
-          <IconForward className={style.icon} />
-          { renderDate(dates.end) }
-        </div>
-        <div className={style.amount}>
-          {
-            keys(amount).map(type => (
-              <TotalDisplay
-                amount={amount[type].value}
-                color={colors[type]}
-                key={type}
-                title={amount[type].title}
-              />
-            ))
-          }
-        </div>
-      </div>
-    </CardContent>
-  </CardSection>
+  <div className={style.content}>
+    <div className={style.dates}>
+      { renderDate(dates.start) }
+      <IconForward className={style.icon} />
+      { renderDate(dates.end) }
+    </div>
+    <div className={style.amount}>
+      {
+        keys(amount).map(type => (
+          <TotalDisplay
+            amount={amount[type].value}
+            color={colors[type]}
+            key={type}
+            title={amount[type].title}
+          />
+        ))
+      }
+    </div>
+  </div>
 )
 
 const totalShape = PropTypes.shape({

--- a/packages/pilot/src/components/BalanceTotalDisplay/index.js
+++ b/packages/pilot/src/components/BalanceTotalDisplay/index.js
@@ -1,8 +1,7 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import {
   Button,
-  Card,
   CardContent,
   CardTitle,
 } from 'former-kit'
@@ -16,7 +15,7 @@ const BalanceTotalDisplay = ({
   disabled,
   title,
 }) => (
-  <Card>
+  <Fragment>
     <CardTitle
       className={style.title}
       title={title}
@@ -38,7 +37,7 @@ const BalanceTotalDisplay = ({
         </Button>
       }
     </CardContent>
-  </Card>
+  </Fragment>
 )
 
 BalanceTotalDisplay.propTypes = {

--- a/packages/pilot/src/components/PendingRequests/index.js
+++ b/packages/pilot/src/components/PendingRequests/index.js
@@ -1,8 +1,7 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import {
   Button,
-  Card,
   CardContent,
   CardTitle,
 } from 'former-kit'
@@ -47,7 +46,7 @@ const PendingRequests = ({
   requests,
   title,
 }) => (
-  <Card>
+  <Fragment>
     <CardTitle className={style.title} title={title} />
     <CardContent>
       {!isEmpty(requests) &&
@@ -61,7 +60,7 @@ const PendingRequests = ({
         <p>{emptyMessage}</p>
       }
     </CardContent>
-  </Card>
+  </Fragment>
 )
 
 PendingRequests.defaultProps = {

--- a/packages/pilot/src/containers/Balance/index.js
+++ b/packages/pilot/src/containers/Balance/index.js
@@ -353,18 +353,18 @@ class Balance extends Component {
             tv={4}
           >
             <Card>
-            <BalanceTotalDisplay
-              action={isNil(onWithdrawClick) ? null : withdrawalAction}
-              amount={formatAmount(amount)}
-              detail={
-                <span>
-                  {t('pages.balance.available_withdrawal')}
-                  <strong> {currencyFormatter(withdrawal)} </strong>
-                </span>
-              }
-              disabled={disabled}
-              title={t('pages.balance.withdrawal_title')}
-            />
+              <BalanceTotalDisplay
+                action={isNil(onWithdrawClick) ? null : withdrawalAction}
+                amount={formatAmount(amount)}
+                detail={
+                  <span>
+                    {t('pages.balance.available_withdrawal')}
+                    <strong> {currencyFormatter(withdrawal)} </strong>
+                  </span>
+                }
+                disabled={disabled}
+                title={t('pages.balance.withdrawal_title')}
+              />
             </Card>
           </Col>
           <Col
@@ -374,13 +374,13 @@ class Balance extends Component {
             tv={4}
           >
             <Card>
-            <BalanceTotalDisplay
-              action={isNil(onAnticipationClick) ? null : anticipationAction}
-              amount={formatAmount(outcoming)}
-              detail={this.renderAnticipation()}
-              disabled={disabled || anticipationLoading || anticipationError}
-              title={t('pages.balance.anticipation_title')}
-            />
+              <BalanceTotalDisplay
+                action={isNil(onAnticipationClick) ? null : anticipationAction}
+                amount={formatAmount(outcoming)}
+                detail={this.renderAnticipation()}
+                disabled={disabled || anticipationLoading || anticipationError}
+                title={t('pages.balance.anticipation_title')}
+              />
             </Card>
           </Col>
           <Col
@@ -389,13 +389,15 @@ class Balance extends Component {
             tablet={6}
             tv={4}
           >
-            <PendingRequests
-              emptyMessage={t('pages.balance.pending_requests_empty_message')}
-              loading={disabled}
-              onCancel={isNil(onCancelRequestClick) ? null : this.handleRequestCancelClick}
-              requests={this.getPendingRequests()}
-              title={t('pages.balance.pending_requests_title')}
-            />
+            <Card>
+              <PendingRequests
+                emptyMessage={t('pages.balance.pending_requests_empty_message')}
+                loading={disabled}
+                onCancel={isNil(onCancelRequestClick) ? null : this.handleRequestCancelClick}
+                requests={this.getPendingRequests()}
+                title={t('pages.balance.pending_requests_title')}
+              />
+            </Card>
           </Col>
         </Row>
         <Row>
@@ -431,11 +433,11 @@ class Balance extends Component {
               <CardContent>
                 <CardSection>
                   <CardContent>
-                <BalanceSummary
-                  amount={this.getSummaryTotal()}
-                  dates={dates}
-                />
-              </CardContent>
+                    <BalanceSummary
+                      amount={this.getSummaryTotal()}
+                      dates={dates}
+                    />
+                  </CardContent>
                 </CardSection>
               </CardContent>
             </Card>

--- a/packages/pilot/src/containers/Balance/index.js
+++ b/packages/pilot/src/containers/Balance/index.js
@@ -352,6 +352,7 @@ class Balance extends Component {
             tablet={6}
             tv={4}
           >
+            <Card>
             <BalanceTotalDisplay
               action={isNil(onWithdrawClick) ? null : withdrawalAction}
               amount={formatAmount(amount)}
@@ -364,6 +365,7 @@ class Balance extends Component {
               disabled={disabled}
               title={t('pages.balance.withdrawal_title')}
             />
+            </Card>
           </Col>
           <Col
             desk={4}
@@ -371,6 +373,7 @@ class Balance extends Component {
             tablet={6}
             tv={4}
           >
+            <Card>
             <BalanceTotalDisplay
               action={isNil(onAnticipationClick) ? null : anticipationAction}
               amount={formatAmount(outcoming)}
@@ -378,6 +381,7 @@ class Balance extends Component {
               disabled={disabled || anticipationLoading || anticipationError}
               title={t('pages.balance.anticipation_title')}
             />
+            </Card>
           </Col>
           <Col
             desk={4}

--- a/packages/pilot/src/containers/Balance/index.js
+++ b/packages/pilot/src/containers/Balance/index.js
@@ -15,6 +15,7 @@ import {
   Button,
   Card,
   CardContent,
+  CardSection,
   Col,
   DateInput,
   Grid,
@@ -424,10 +425,14 @@ class Balance extends Component {
                 </div>
               </CardContent>
               <CardContent>
+                <CardSection>
+                  <CardContent>
                 <BalanceSummary
                   amount={this.getSummaryTotal()}
                   dates={dates}
                 />
+              </CardContent>
+                </CardSection>
               </CardContent>
             </Card>
           </Col>

--- a/packages/pilot/src/containers/RecipientDetails/RecipientBalance/index.js
+++ b/packages/pilot/src/containers/RecipientDetails/RecipientBalance/index.js
@@ -1,0 +1,473 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import moment from 'moment'
+
+import {
+  either,
+  isEmpty,
+  isNil,
+  map,
+  pipe,
+  propSatisfies,
+  take,
+} from 'ramda'
+
+import {
+  Button,
+  Card,
+  CardContent,
+  CardSection,
+  Col,
+  DateInput,
+  Grid,
+  Row,
+  Spacing,
+  Tooltip,
+} from 'former-kit'
+
+import IconCalendar from 'emblematic-icons/svg/Calendar32.svg'
+import IconInfo from 'emblematic-icons/svg/Info32.svg'
+
+import BalanceSummary from '../../../components/BalanceSummary'
+import BalanceTotalDisplay from '../../../components/BalanceTotalDisplay'
+import bulkAnticipationsLabels from '../../../models/bulkAnticipationTypes'
+import currencyFormatter from '../../../formatters/currency'
+import dateFormatter from '../../../formatters/longDate'
+import dateLimits from '../../../models/dateSelectorLimits'
+import datePresets from '../../../models/dateSelectorPresets'
+import getColumns from '../../../components/Operations/operationsTableColumns'
+import getColumnsTranslator from '../../../formatters/columnTranslator'
+import Operations from '../../../components/Operations'
+import operationsTypesLabels from '../../../models/operationTypes'
+import PendingRequests from '../../../components/PendingRequests'
+import style from './style.css'
+
+const getDateLabels = t => ({
+  anyDate: t('dates.any'),
+  cancel: t('dates.cancel'),
+  confirmPeriod: t('dates.confirm'),
+  custom: t('dates.custom'),
+  day: t('dates.day'),
+  daySelected: t('dates.day_selected'),
+  daysSelected: t('dates.selected'),
+  end: t('dates.end'),
+  noDayOrPeriodSelected: t('dates.no_selected'),
+  period: t('dates.period'),
+  select: t('dates.select'),
+  start: t('dates.start'),
+  today: t('dates.today'),
+})
+
+const datesEqual = (left, right) => {
+  if (left.start === right.start && left.end === right.end) {
+    return true
+  }
+
+  return (
+    moment(left.start).diff(moment(right.start), 'days') === 0
+    && moment(right.end).diff(moment(right.end), 'days') === 0
+  )
+}
+
+const isEmptyDates = either(
+  propSatisfies(isNil, 'end'),
+  propSatisfies(isNil, 'start')
+)
+
+const anyDateRange = {
+  end: moment(),
+  start: moment().subtract(3, 'months'),
+}
+
+const formatAmount = (amount = 0) =>
+  currencyFormatter(amount)
+
+class RecipientBalance extends Component {
+  constructor (props) {
+    super(props)
+
+    this.getPendingRequest = this.getPendingRequest.bind(this)
+    this.getPendingRequests = this.getPendingRequests.bind(this)
+    this.getSummaryTotal = this.getSummaryTotal.bind(this)
+    this.handleFilterClick = this.handleFilterClick.bind(this)
+    this.handleDatesChange = this.handleDatesChange.bind(this)
+    this.handleOperationsPageChange = this.handleOperationsPageChange.bind(this)
+    this.handleRequestCancelClick = this.handleRequestCancelClick.bind(this)
+    this.renderAnticipation = this.renderAnticipation.bind(this)
+
+    this.state = {
+      dates: {
+        end: props.dates.end,
+        start: props.dates.start,
+      },
+    }
+  }
+
+  getPendingRequest ({
+    amount,
+    created_at: createdAt,
+    type,
+  }) {
+    const { t } = this.props
+    const title = bulkAnticipationsLabels[type] || '-'
+    return {
+      amount: currencyFormatter(amount),
+      created_at: dateFormatter(createdAt),
+      title: t(title),
+    }
+  }
+
+  getPendingRequests () {
+    const {
+      requests,
+    } = this.props
+
+    const getRequests = pipe(
+      take(3),
+      map(this.getPendingRequest)
+    )
+
+    return getRequests(requests)
+  }
+
+  getSummaryTotal () {
+    const {
+      disabled,
+      total,
+      t,
+    } = this.props
+
+    if (!isEmpty(total)) {
+      return {
+        outcoming: {
+          title: t('pages.balance.total.outcoming'),
+          unit: t('currency'),
+          value: disabled ? 0 : total.outcoming,
+        },
+        outgoing: {
+          title: t('pages.balance.total.outgoing'),
+          unit: t('currency'),
+          value: disabled ? 0 : -total.outgoing,
+        },
+        net: {
+          title: t('pages.balance.total.net'),
+          unit: t('currency'),
+          value: disabled ? 0 : total.net,
+        },
+      }
+    }
+
+    return null
+  }
+
+  handleDatesChange (dates) {
+    this.setState({ dates })
+  }
+
+  handleFilterClick () {
+    if (isEmptyDates(this.state.dates)) {
+      this.props.onFilterClick(anyDateRange)
+    } else {
+      this.props.onFilterClick(this.state.dates)
+    }
+  }
+
+  handleOperationsPageChange (pageIndex) {
+    const { onPageChange } = this.props
+    onPageChange(pageIndex)
+  }
+
+  handleRequestCancelClick (requestIndex) {
+    const {
+      onCancelRequestClick,
+      requests,
+    } = this.props
+
+    onCancelRequestClick(requests[requestIndex].id)
+  }
+
+  renderAnticipation () {
+    const {
+      anticipation: {
+        available,
+        error,
+        loading,
+      },
+      t,
+    } = this.props
+
+    if (loading) {
+      return (
+        <span>
+          {t('pages.balance.anticipation_loading')}
+        </span>
+      )
+    }
+
+    if (error) {
+      return (
+        <span>
+          {t('pages.balance.anticipation_error')}
+          <Spacing size="tiny" />
+          <Tooltip
+            placement="rightMiddle"
+            content={t('pages.balance.anticipation_error_info')}
+          >
+            <IconInfo height={16} width={16} />
+          </Tooltip>
+        </span>
+      )
+    }
+
+    return (
+      <span>
+        {t('pages.balance.available_anticipation')}
+        <strong> {formatAmount(available)} </strong>
+      </span>
+    )
+  }
+
+  render () {
+    const {
+      anticipation: {
+        error: anticipationError,
+        loading: anticipationLoading,
+      },
+      balance: {
+        amount,
+        available: {
+          withdrawal,
+        },
+        outcoming,
+      },
+      currentPage,
+      dates,
+      disabled,
+      onAnticipationClick,
+      onCancelRequestClick,
+      onWithdrawClick,
+      search: {
+        operations,
+      },
+      t,
+    } = this.props
+
+    const translateColumns = getColumnsTranslator(t)
+    const typesLabels = map(t, operationsTypesLabels)
+
+    const anticipationAction = {
+      disabled,
+      onClick: onAnticipationClick,
+      title: t('pages.balance.anticipation'),
+    }
+
+    const withdrawalAction = {
+      disabled,
+      onClick: onWithdrawClick,
+      title: t('pages.balance.withdraw'),
+    }
+
+    const filterDatesEqualCurrent = datesEqual(this.state.dates, dates)
+
+    return (
+      <Grid>
+        <Row stretch>
+          <Col
+            desk={4}
+            palm={12}
+            tablet={6}
+            tv={4}
+          >
+            <CardSection>
+              <BalanceTotalDisplay
+                action={isNil(onWithdrawClick) ? null : withdrawalAction}
+                amount={formatAmount(amount)}
+                detail={
+                  <span>
+                    {t('pages.balance.available_withdrawal')}
+                    <strong> {currencyFormatter(withdrawal)} </strong>
+                  </span>
+                }
+                disabled={disabled}
+                title={t('pages.balance.withdrawal_title')}
+              />
+            </CardSection>
+          </Col>
+          <Col
+            desk={4}
+            palm={12}
+            tablet={6}
+            tv={4}
+          >
+            <CardSection>
+              <BalanceTotalDisplay
+                action={isNil(onAnticipationClick) ? null : anticipationAction}
+                amount={formatAmount(outcoming)}
+                detail={this.renderAnticipation()}
+                disabled={disabled || anticipationLoading || anticipationError}
+                title={t('pages.balance.anticipation_title')}
+              />
+            </CardSection>
+          </Col>
+          <Col
+            desk={4}
+            palm={12}
+            tablet={6}
+            tv={4}
+          >
+            <CardSection>
+              <PendingRequests
+                emptyMessage={t('pages.balance.pending_requests_empty_message')}
+                loading={disabled}
+                onCancel={isNil(onCancelRequestClick) ? null : this.handleRequestCancelClick}
+                requests={this.getPendingRequests()}
+                title={t('pages.balance.pending_requests_title')}
+              />
+            </CardSection>
+          </Col>
+        </Row>
+        <Row>
+          <Col
+            desk={12}
+            palm={12}
+            tablet={12}
+            tv={12}
+          >
+            <CardSection>
+              <CardContent>
+                <div className={style.filter}>
+                  <DateInput
+                    active={filterDatesEqualCurrent}
+                    value={this.state.dates}
+                    disabled={disabled}
+                    icon={<IconCalendar width={16} height={16} />}
+                    limits={dateLimits}
+                    onChange={this.handleDatesChange}
+                    presets={datePresets}
+                    strings={getDateLabels(this.props.t)}
+                  />
+                  <Button
+                    disabled={filterDatesEqualCurrent}
+                    fill="gradient"
+                    onClick={this.handleFilterClick}
+                    size="default"
+                  >
+                    {t('filter_action')}
+                  </Button>
+                </div>
+              </CardContent>
+              <CardContent>
+                <Card>
+                  <CardContent>
+                    <BalanceSummary
+                      amount={this.getSummaryTotal()}
+                      dates={dates}
+                    />
+                  </CardContent>
+                </Card>
+              </CardContent>
+              <Operations
+                columns={translateColumns(getColumns(typesLabels))}
+                currentPage={currentPage}
+                disabled={disabled}
+                emptyMessage={t('models.operations.empty_message')}
+                exportLabel={t('models.operations.export')}
+                loading={disabled}
+                ofLabel={t('of')}
+                onExport={() => null}
+                onPageChange={this.handleOperationsPageChange}
+                rows={operations.rows}
+                subtitle={
+                  <span>
+                    {t('pages.balance.total.of')}
+                    <strong> {operations.total} </strong>
+                    {t('pages.balance.releases')}
+                  </span>
+                }
+                title={t('pages.balance.operations_title')}
+                totalPages={operations.count}
+              />
+            </CardSection>
+          </Col>
+        </Row>
+      </Grid>
+    )
+  }
+}
+
+const cashFlowShape = PropTypes.arrayOf(
+  PropTypes.shape({
+    amount: PropTypes.number.isRequired,
+    type: PropTypes.string.isRequired,
+  })
+).isRequired
+
+const numberOrStringShape = PropTypes.oneOfType([
+  PropTypes.string.isRequired,
+  PropTypes.number.isRequired,
+]).isRequired
+
+RecipientBalance.propTypes = {
+  anticipation: PropTypes.shape({
+    error: PropTypes.bool.isRequired,
+    loading: PropTypes.bool.isRequired,
+    available: PropTypes.number,
+  }).isRequired,
+  balance: PropTypes.shape({
+    amount: PropTypes.number.isRequired,
+    available: PropTypes.shape({
+      withdrawal: PropTypes.number.isRequired,
+    }),
+    outcoming: PropTypes.number.isRequired,
+  }).isRequired,
+  currentPage: PropTypes.number.isRequired,
+  dates: PropTypes.shape({
+    end: PropTypes.instanceOf(moment),
+    start: PropTypes.instanceOf(moment),
+  }).isRequired,
+  disabled: PropTypes.bool.isRequired,
+  onAnticipationClick: PropTypes.func.isRequired,
+  onCancelRequestClick: PropTypes.func,
+  onFilterClick: PropTypes.func.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+  onWithdrawClick: PropTypes.func.isRequired,
+  requests: PropTypes.arrayOf(PropTypes.shape({
+    amount: PropTypes.number,
+    created_at: PropTypes.string,
+    id: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+  })).isRequired,
+  search: PropTypes.shape({
+    operations: PropTypes.shape({
+      count: PropTypes.number.isRequired,
+      offset: PropTypes.number.isRequired,
+      rows: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: numberOrStringShape,
+          net: PropTypes.number.isRequired,
+          outcoming: cashFlowShape,
+          outgoing: cashFlowShape,
+          payment_date: PropTypes.shape({
+            original: PropTypes.string,
+            actual: PropTypes.string.isRequired,
+          }),
+          type: PropTypes.string.isRequired,
+        })
+      ),
+      total: PropTypes.number.isRequired,
+    }),
+  }).isRequired,
+  t: PropTypes.func.isRequired,
+  total: PropTypes.shape({
+    net: PropTypes.number,
+    outcoming: PropTypes.number,
+    outgoing: PropTypes.number,
+  }),
+}
+
+RecipientBalance.defaultProps = {
+  onCancelRequestClick: null,
+  total: {},
+}
+
+export default RecipientBalance

--- a/packages/pilot/src/containers/RecipientDetails/RecipientBalance/style.css
+++ b/packages/pilot/src/containers/RecipientDetails/RecipientBalance/style.css
@@ -1,0 +1,5 @@
+@import "former-kit-skin-pagarme/dist/styles/spacing.css";
+
+.filter > button {
+  margin-left: var(--spacing-small);
+}

--- a/packages/pilot/stories/components/BalanceSummary/index.js
+++ b/packages/pilot/stories/components/BalanceSummary/index.js
@@ -1,5 +1,10 @@
 import React from 'react'
 import moment from 'moment'
+import {
+  CardContent,
+  CardSection,
+} from 'former-kit'
+
 import Section from '../../Section'
 import BalanceSummary from '../../../src/components/BalanceSummary'
 
@@ -23,13 +28,17 @@ const amount = {
 
 const BalanceSummaryExample = () => (
   <Section>
-    <BalanceSummary
-      amount={amount}
-      dates={{
-        end: moment(),
-        start: moment().subtract(4, 'days'),
-      }}
-    />
+    <CardSection>
+      <CardContent>
+        <BalanceSummary
+          amount={amount}
+          dates={{
+            end: moment(),
+            start: moment().subtract(4, 'days'),
+          }}
+        />
+      </CardContent>
+    </CardSection>
   </Section>
 )
 

--- a/packages/pilot/stories/components/BalanceTotalDisplay/index.js
+++ b/packages/pilot/stories/components/BalanceTotalDisplay/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Grid, Row, Col } from 'former-kit'
+import { Card, Grid, Row, Col } from 'former-kit'
 import { action } from '@storybook/addon-actions'
 
 import Section from '../../Section'
@@ -10,27 +10,31 @@ const BalanceTotalDisplayExample = () => (
     <Grid>
       <Row>
         <Col palm={12} tablet={6} desk={4} tv={4}>
-          <BalanceTotalDisplay
-            title="Saldo Atual"
-            amount="R$ 15.000,00"
-            detail={<span>Liberado para saque: <strong>R$5.000,00</strong></span>}
-            action={{
-              title: 'Sacar',
-              onClick: action('clicked'),
-            }}
-          />
+          <Card>
+            <BalanceTotalDisplay
+              title="Saldo Atual"
+              amount="R$ 15.000,00"
+              detail={<span>Liberado para saque: <strong>R$5.000,00</strong></span>}
+              action={{
+                title: 'Sacar',
+                onClick: action('clicked'),
+              }}
+            />
+          </Card>
         </Col>
 
         <Col palm={12} tablet={6} desk={4} tv={4}>
-          <BalanceTotalDisplay
-            title="A Receber"
-            amount="R$ 7.000,00"
-            detail={<span>Liberado para saque: <strong>R$5.000,00</strong></span>}
-            action={{
-              title: 'Antecipar',
-              onClick: action('clicked'),
-            }}
-          />
+          <Card>
+            <BalanceTotalDisplay
+              title="A Receber"
+              amount="R$ 7.000,00"
+              detail={<span>Liberado para saque: <strong>R$5.000,00</strong></span>}
+              action={{
+                title: 'Antecipar',
+                onClick: action('clicked'),
+              }}
+            />
+          </Card>
         </Col>
       </Row>
     </Grid>

--- a/packages/pilot/stories/components/PendingRequests/index.js
+++ b/packages/pilot/stories/components/PendingRequests/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Card } from 'former-kit'
 import { action } from '@storybook/addon-actions'
 
 import Section from '../../Section'
@@ -24,11 +25,13 @@ const requests = [
 ]
 const PendingRequestsExample = () => (
   <Section>
-    <PendingRequests
-      title="Solicitações pendentes"
-      requests={requests}
-      onCancel={action('cancel-request')}
-    />
+    <Card>
+      <PendingRequests
+        title="Solicitações pendentes"
+        requests={requests}
+        onCancel={action('cancel-request')}
+      />
+    </Card>
   </Section>
 )
 

--- a/packages/pilot/stories/containers/RecipientDetails/RecipientBalance/index.js
+++ b/packages/pilot/stories/containers/RecipientDetails/RecipientBalance/index.js
@@ -1,0 +1,96 @@
+import React, { Component } from 'react'
+import { action } from '@storybook/addon-actions'
+import moment from 'moment'
+import { merge } from 'ramda'
+
+import {
+  Card,
+  CardContent,
+} from 'former-kit'
+
+import RecipientBalance from '../../../../src/containers/RecipientDetails/RecipientBalance'
+import Section from '../../../Section'
+import mock from '../../../../src/containers/Balance/mock.json'
+
+
+class RecipientBalanceState extends Component {
+  constructor () {
+    super()
+
+    this.handleDateChange = this.handleDateChange.bind(this)
+    this.state = {
+      anticipation: {
+        available: 10000,
+        error: false,
+        loading: false,
+      },
+      dates: {
+        end: moment().add(1, 'month'),
+        start: moment(),
+      },
+      ...mock,
+      query: {
+        dates: {
+          end: moment().add(1, 'month'),
+          start: moment(),
+        },
+        page: 1,
+      },
+      total: {
+        net: 1000000,
+        outcoming: 1000000,
+        outgoing: 1000000,
+      },
+    }
+  }
+
+  handleDateChange (dates) {
+    const { query } = this.state
+    action('date change')
+    this.setState({
+      query: merge(query, { dates }),
+    })
+  }
+
+
+  render () {
+    const {
+      anticipation,
+      dates,
+      result: {
+        requests,
+        balance,
+        search,
+      },
+      query,
+      total,
+    } = this.state
+
+    return (
+      <Section>
+        <Card>
+          <CardContent>
+            <RecipientBalance
+              anticipation={anticipation}
+              balance={balance}
+              currentPage={query.page}
+              dates={dates}
+              disabled={false}
+              onAnticipationClick={action('anticipation')}
+              onCancelRequestClick={action('cancel request')}
+              onFilterClick={action('filter click')}
+              onPageChange={action('page click')}
+              onWithdrawClick={action('withdraw')}
+              requests={requests}
+              search={search}
+              t={t => t}
+              total={total}
+            />
+          </CardContent>
+        </Card>
+      </Section>
+    )
+  }
+}
+
+export default RecipientBalanceState

--- a/packages/pilot/stories/containers/index.js
+++ b/packages/pilot/stories/containers/index.js
@@ -60,6 +60,7 @@ import ConclusionStepSuccess from './AddRecipient/ConclusionStep/Success'
 import ConclusionStepFail from './AddRecipient/ConclusionStep/Fail'
 import ConfigurationStep from './AddRecipient/ConfigurationsStep'
 import RecipientDetailInfo from './RecipientDetailInfo'
+import RecipientBalance from './RecipientDetails/RecipientBalance'
 
 storiesOf('Containers', module)
   .add('Recipient Detail Info', () => (
@@ -148,6 +149,9 @@ storiesOf('Containers', module)
   ))
   .add('Balance', () => (
     <Balance />
+  ))
+  .add('Recipient balance', () => (
+    <RecipientBalance />
   ))
   .add('Reprocess form', () => (
     <ReprocessForm />


### PR DESCRIPTION
## Contexto
Adiciona o componente de extrato do recebedor, que vai compor uma das abas da página de Detalhes do Recebedor.

## Checklist
- [x] Refatora alguns componentes utilizados por `<Balance>` para que eles possam ser reutilizados;
- [x] Adiciona o componente `<RecipientBalance>`, que foi baseado a partir do componente `<Balance>`.

## Issues linkadas
- [x] Resolves https://github.com/pagarme/caesar/issues/262

## Screenshots

### Layout:
[Layout do zeplin](https://app.zeplin.io/project/59e66a0aa633e7a9cf5c0cf4/screen/5b68ca9380c45b7de90ed526)

### Preview:

![05](https://user-images.githubusercontent.com/28565117/44048842-ec2e333e-9f08-11e8-91c6-fa9b023e24c1.png)
