### PR TITLE
Transações: Modal de Captura

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -527,6 +527,19 @@
       "withdrawal_title": "Saldo atual",
       "unknown_error": "Olá, para você poder visualizar as informações do seu extrato é necessário que as extensões do tipo AdBlock estejam desabilitadas."
     },
+    "capture": {
+      "capture_action": "Capturar",
+      "identification": "Identificação",
+      "greater_than_zero": "O valor deve ser maior que zero",
+      "invalid_amount": "Valor para captura inválido",
+      "number": "Deve ser um número",
+      "confirmation": "Confirmação",
+      "success": "Transação capturada com sucesso!",
+      "title": "Capturar transação",
+      "token_capture_warning": "Como esta transação foi criada com sua chave de criptografia, a captura manual pode listar um valor diferente do desejado.",
+      "token_capture_link": "Mais informações",
+      "value_to_capture": "Valor a ser capturado R$"
+    },
     "manual_review": {
       "approve_action": "Aprovar transação",
       "legal_warning_approves_approve": "aprovação.",

--- a/packages/pilot/src/components/CaptureDetails/index.js
+++ b/packages/pilot/src/components/CaptureDetails/index.js
@@ -1,0 +1,79 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import { mapObjIndexed } from 'ramda'
+import {
+  Col,
+  Row,
+} from 'former-kit'
+
+import Property from '../Property'
+
+const renderProperty = (title, value) => (
+  <Property
+    title={title}
+    value={value}
+  />
+)
+
+const fields = (labels, contents) => mapObjIndexed((label, key) =>
+  renderProperty(label, contents[key]),
+labels)
+
+const CaptureDetails = ({
+  contents, labels,
+}) => {
+  const {
+    cardBrand,
+    cardNumber,
+    customerEmail,
+    customerName,
+    installments,
+  } = fields(labels, contents)
+
+  return (
+    <Fragment>
+      { (contents.customerName || contents.customerEmail) &&
+        <Row>
+          <Col palm={12} tablet={8} desk={8} tv={8}>
+            {customerName}
+          </Col>
+          <Col palm={12} tablet={4} desk={4} tv={4}>
+            {customerEmail}
+          </Col>
+        </Row>
+      }
+      { contents.cardNumber &&
+        <Row>
+          <Col palm={12} tablet={4} desk={4} tv={4}>
+            {cardNumber}
+          </Col>
+          <Col palm={12} tablet={4} desk={4} tv={4}>
+            {cardBrand}
+          </Col>
+          <Col palm={12} tablet={4} desk={4} tv={4}>
+            {installments}
+          </Col>
+        </Row>
+      }
+    </Fragment>
+  )
+}
+
+CaptureDetails.propTypes = {
+  labels: PropTypes.shape({
+    cardBrand: PropTypes.string,
+    cardNumber: PropTypes.string,
+    customerEmail: PropTypes.string,
+    customerName: PropTypes.string,
+    installments: PropTypes.string,
+  }).isRequired,
+  contents: PropTypes.shape({
+    cardBrand: PropTypes.node,
+    cardNumber: PropTypes.node,
+    customerEmail: PropTypes.node,
+    customerName: PropTypes.node,
+    installments: PropTypes.node,
+  }).isRequired,
+}
+
+export default CaptureDetails

--- a/packages/pilot/src/containers/Capture/Form/index.js
+++ b/packages/pilot/src/containers/Capture/Form/index.js
@@ -1,0 +1,228 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  Alert,
+  Button,
+  Col,
+  Flexbox,
+  FormInput,
+  Grid,
+  ModalActions,
+  ModalContent,
+  Row,
+  Spacing,
+} from 'former-kit'
+import Form from 'react-vanilla-form'
+import WarningIcon from 'emblematic-icons/svg/Warning32.svg'
+
+import Property from '../../../components/Property'
+import currency from '../../../formatters/currency'
+import CaptureDetails from '../../../components/CaptureDetails'
+import CurrencyInput from '../../../components/CurrencyInput'
+import formatCardNumber from '../../../formatters/cardNumber'
+import numberValidation from '../../../validation/number'
+import requiredValidation from '../../../validation/required'
+import greaterThanValidation from '../../../validation/greaterThan'
+import lessThanOrEqualValidation from '../../../validation/lessThanOrEqual'
+
+import style from './style.css'
+
+const isRequired = t => requiredValidation(t('pages.required_error'))
+const isNumber = t => numberValidation(t('pages.capture.number'))
+
+const greaterThanAuthorized = (authorizedAmount, t) =>
+  greaterThanValidation(authorizedAmount, t('pages.capture.invalid_amount'))
+const lessThanOrEqualZero = t =>
+  lessThanOrEqualValidation(0, t('pages.capture.greater_than_zero'))
+
+const CaptureForm = ({
+  authorizedAmount,
+  cardBrand,
+  cardFirstDigits,
+  cardLastDigits,
+  captureAmount,
+  customerName,
+  customerEmail,
+  disabled,
+  isFromCheckout,
+  installments,
+  onConfirm,
+  t,
+}) => {
+  const labels = {
+    amount: t('pages.transaction.header.card_amount'),
+    captureAmount: t('pages.capture.value_to_capture'),
+    cardBrand: t('models.card.brand'),
+    cardNumber: t('models.card.number'),
+    customerName: t('models.customer.name'),
+    customerEmail: t('models.customer.email'),
+    installments: t('installments'),
+  }
+
+  const contents = {
+    cardBrand,
+    cardNumber: cardFirstDigits && cardLastDigits ? `${formatCardNumber(cardFirstDigits)} ${cardLastDigits}` : '',
+    customerName,
+    customerEmail,
+    installments,
+  }
+
+  const renderCaptureAmount = () => (
+    isFromCheckout
+      ? (
+        <Property
+          title={t('pages.capture.value_to_capture')}
+          value={
+            <span className={style.captureAmount}>
+              {currency(captureAmount)}
+            </span>
+          }
+        />
+      )
+      : (
+        <FormInput
+          disabled={disabled}
+          label={t('pages.transaction.paid_amount')}
+          name="captureAmount"
+          renderer={props => (
+            <CurrencyInput
+              {...props}
+              max={authorizedAmount}
+            />
+          )}
+          type="text"
+          value={captureAmount}
+        />
+      )
+  )
+
+  const renderCaptureWarning = () => (
+    isFromCheckout
+      ? (
+        <Row>
+          <Col palm={12} tablet={12} desk={12} tv={12}>
+            <Alert
+              icon={
+                <WarningIcon
+                  height={16}
+                  width={16}
+                />
+              }
+              type="warning"
+            >
+              <Flexbox
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <span>
+                  {t('pages.capture.token_capture_warning')}
+                </span>
+                <a href="https://google.com">
+                  {t('pages.capture.token_capture_link')}
+                </a>
+              </Flexbox>
+            </Alert>
+          </Col>
+        </Row>
+      ) : null
+  )
+
+  return (
+    <Form
+      data={{
+        captureAmount,
+      }}
+      validation={{
+        captureAmount: [
+          isRequired(t),
+          isNumber(t),
+          greaterThanAuthorized(authorizedAmount, t),
+          lessThanOrEqualZero(t),
+        ],
+      }}
+      onSubmit={onConfirm}
+    >
+      <ModalContent>
+        <Grid>
+          <CaptureDetails labels={labels} contents={contents} />
+          <Row>
+            <Col palm={12} tablet={8} desk={8} tv={8}>
+              <Property
+                title={t('pages.transaction.header.card_amount')}
+                value={currency(authorizedAmount)}
+              />
+            </Col>
+            <Col palm={12} tablet={4} desk={4} tv={4}>
+              { renderCaptureAmount() }
+            </Col>
+          </Row>
+          { renderCaptureWarning() }
+        </Grid>
+      </ModalContent>
+      <Spacing />
+      <ModalActions>
+        <Button
+          disabled={disabled}
+          type="submit"
+        >
+          {t('pages.capture.capture_action')}
+        </Button>
+      </ModalActions>
+    </Form>
+  )
+}
+
+const mustEqualAuthorizedAmountOnCheckoutCapture = (props, propName) => {
+  const {
+    authorizedAmount,
+    captureAmount,
+    isFromCheckout,
+  } = props
+
+  if (propName === 'captureAmount' && isFromCheckout && authorizedAmount !== Number(captureAmount)) {
+    throw new Error('Prop captureAmount should equals authorizedAmount')
+  }
+}
+
+const requiredOnCheckoutCapture = (props, propName) => {
+  const {
+    isFromCheckout,
+  } = props
+
+  if (!props[propName] && isFromCheckout) {
+    throw new Error(`Prop ${propName} is needed when isFromCheckout equals true`)
+  }
+}
+
+const captureAmountPropType = (props, propName) => {
+  requiredOnCheckoutCapture(props, propName)
+  mustEqualAuthorizedAmountOnCheckoutCapture(props, propName)
+}
+
+CaptureForm.propTypes = {
+  authorizedAmount: PropTypes.number.isRequired,
+  cardBrand: PropTypes.string,
+  cardFirstDigits: PropTypes.string,
+  cardLastDigits: PropTypes.string,
+  captureAmount: captureAmountPropType,
+  customerName: PropTypes.string,
+  customerEmail: PropTypes.string,
+  disabled: PropTypes.bool,
+  isFromCheckout: PropTypes.bool.isRequired,
+  installments: PropTypes.number,
+  onConfirm: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired,
+}
+
+CaptureForm.defaultProps = {
+  captureAmount: '0',
+  cardBrand: null,
+  cardFirstDigits: '',
+  cardLastDigits: '',
+  customerName: null,
+  customerEmail: null,
+  disabled: false,
+  installments: null,
+}
+
+export default CaptureForm

--- a/packages/pilot/src/containers/Capture/Form/style.css
+++ b/packages/pilot/src/containers/Capture/Form/style.css
@@ -1,0 +1,10 @@
+@import "former-kit-skin-pagarme/dist/styles/typography.css";
+@import "former-kit-skin-pagarme/dist/styles/spacing.css";
+@import "former-kit-skin-pagarme/dist/styles/colors/light.css";
+
+.captureAmount {
+  color: var(--color-light-steel-100);
+  font-size: var(--headline-font-size);
+  font-weight: var(--title-font-weight);
+  margin: 0;
+}

--- a/packages/pilot/src/containers/Capture/Result/index.js
+++ b/packages/pilot/src/containers/Capture/Result/index.js
@@ -1,0 +1,150 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import {
+  Alert,
+  Button,
+  Col,
+  Grid,
+  ModalActions,
+  ModalContent,
+  Row,
+  Spacing,
+} from 'former-kit'
+import IconError from 'emblematic-icons/svg/ClearClose32.svg'
+
+import Property from '../../../components/Property'
+import currency from '../../../formatters/currency'
+import CaptureDetails from '../../../components/CaptureDetails'
+import { Message } from '../../../components/Message'
+import formatCardNumber from '../../../formatters/cardNumber'
+
+import style from './style.css'
+
+const Result = ({
+  authorizedAmount,
+  cardBrand,
+  cardFirstDigits,
+  cardLastDigits,
+  customerName,
+  customerEmail,
+  image,
+  installments,
+  message,
+  onRetry,
+  onViewTransaction,
+  paidAmount,
+  status,
+  statusMessage,
+  t,
+}) => (
+  <Fragment>
+    <ModalContent>
+      { status === 'current'
+        ?
+          <div>
+            <div className={style.image}>
+              <Message
+                image={image}
+                message={message}
+              />
+            </div>
+            <Grid>
+              <CaptureDetails
+                labels={{
+                  cardBrand: t('models.card.brand'),
+                  cardNumber: t('models.card.number'),
+                  customerName: t('models.customer.name'),
+                  customerEmail: t('models.customer.email'),
+                  installments: t('installments'),
+                }}
+                contents={{
+                  cardBrand,
+                  cardNumber: `${formatCardNumber(cardFirstDigits)} ${cardLastDigits}`,
+                  customerName,
+                  customerEmail,
+                  installments,
+                }}
+              />
+              <Row>
+                <Col palm={12} tablet={8} desk={8} tv={8}>
+                  <Property
+                    title={t('pages.transaction.header.card_amount')}
+                    value={currency(authorizedAmount)}
+                  />
+                </Col>
+                <Col palm={12} tablet={4} desk={4} tv={4}>
+                  <Property
+                    title={t('pages.transaction.paid_amount')}
+                    value={
+                      <span className={style.capturedAmount}>
+                        {currency(paidAmount)}
+                      </span>
+                    }
+                  />
+                </Col>
+              </Row>
+            </Grid>
+          </div>
+        :
+          <Alert
+            icon={<IconError height={16} width={16} />}
+            type="error"
+          >
+            {statusMessage}
+          </Alert>
+      }
+    </ModalContent>
+    <Spacing />
+    <ModalActions>
+      { status === 'current'
+        ?
+          <Button
+            fill="outline"
+            onClick={onViewTransaction}
+          >
+            {t('view_transaction')}
+          </Button>
+        :
+          <Button
+            fill="outline"
+            onClick={onRetry}
+          >
+            {t('try_again')}
+          </Button>
+      }
+    </ModalActions>
+  </Fragment>
+)
+
+Result.propTypes = {
+  authorizedAmount: PropTypes.number.isRequired,
+  cardBrand: PropTypes.string,
+  cardFirstDigits: PropTypes.string,
+  cardLastDigits: PropTypes.string,
+  customerName: PropTypes.string,
+  customerEmail: PropTypes.string,
+  image: PropTypes.node.isRequired,
+  installments: PropTypes.number,
+  message: PropTypes.node.isRequired,
+  onRetry: PropTypes.func.isRequired,
+  onViewTransaction: PropTypes.func.isRequired,
+  paidAmount: PropTypes.number.isRequired,
+  status: PropTypes.oneOf([
+    'current',
+    'error',
+  ]).isRequired,
+  statusMessage: PropTypes.string,
+  t: PropTypes.func.isRequired,
+}
+
+Result.defaultProps = {
+  cardBrand: null,
+  cardFirstDigits: null,
+  cardLastDigits: null,
+  customerName: null,
+  customerEmail: null,
+  installments: 0,
+  statusMessage: null,
+}
+
+export default Result

--- a/packages/pilot/src/containers/Capture/Result/style.css
+++ b/packages/pilot/src/containers/Capture/Result/style.css
@@ -1,0 +1,13 @@
+@import "former-kit-skin-pagarme/dist/styles/spacing.css";
+@import "former-kit-skin-pagarme/dist/styles/typography.css";
+
+.image {
+  margin-bottom: var(--spacing-large);
+}
+
+.capturedAmount {
+  color: var(--color-light-steel-100);
+  font-size: var(--headline-font-size);
+  font-weight: var(--title-font-weight);
+  margin: 0;
+}

--- a/packages/pilot/src/containers/Capture/index.js
+++ b/packages/pilot/src/containers/Capture/index.js
@@ -1,0 +1,156 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  Modal,
+  ModalContent,
+  ModalSection,
+  ModalTitle,
+  Steps,
+} from 'former-kit'
+import IconClose from 'emblematic-icons/svg/ClearClose32.svg'
+import ErrorIcon from '../../components/TransferError/ErrorIcon.svg'
+
+import CaptureForm from './Form'
+import CaptureResult from './Result'
+
+const Capture = ({
+  captureAmount,
+  isFromCheckout,
+  isOpen,
+  loading,
+  onConfirm,
+  onCancel,
+  onRetry,
+  onViewTransaction,
+  stepStatus,
+  statusMessage,
+  t,
+  transaction,
+}) => {
+  const {
+    card: {
+      brand_name: cardBrand,
+      first_digits: cardFirstDigits,
+      last_digits: cardLastDigits,
+    },
+    customer: {
+      email: customerEmail,
+      name: customerName,
+    },
+    payment: {
+      authorized_amount: authorizedAmount,
+      installments,
+    },
+  } = transaction
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={onCancel}
+    >
+      <ModalTitle
+        closeIcon={<IconClose height={16} width={16} />}
+        onClose={onCancel}
+        title={t('pages.capture.title')}
+      />
+      <ModalContent>
+        <ModalSection>
+          <Steps
+            status={[
+              { id: 'identification', status: stepStatus.identification },
+              { id: 'confirmation', status: stepStatus.confirmation },
+            ]}
+            steps={[
+              { id: 'identification', title: t('pages.capture.identification') },
+              { id: 'confirmation', title: t('pages.capture.confirmation') },
+            ]}
+          />
+        </ModalSection>
+      </ModalContent>
+      { stepStatus.confirmation !== 'pending'
+        ?
+          <CaptureResult
+            authorizedAmount={authorizedAmount}
+            cardBrand={cardBrand}
+            cardFirstDigits={cardFirstDigits}
+            cardLastDigits={cardLastDigits}
+            customerName={customerName}
+            customerEmail={customerEmail}
+            image={<ErrorIcon />}
+            installments={installments}
+            message={t('pages.capture.success')}
+            onRetry={onRetry}
+            onViewTransaction={onViewTransaction}
+            paidAmount={Number(captureAmount)}
+            status={stepStatus.confirmation}
+            statusMessage={statusMessage}
+            t={t}
+          />
+        :
+          <CaptureForm
+            authorizedAmount={authorizedAmount}
+            captureAmount={captureAmount}
+            cardBrand={cardBrand}
+            cardFirstDigits={cardFirstDigits}
+            cardLastDigits={cardLastDigits}
+            customerName={customerName}
+            customerEmail={customerEmail}
+            disabled={loading}
+            isFromCheckout={isFromCheckout}
+            installments={installments}
+            onConfirm={onConfirm}
+            t={t}
+          />
+      }
+    </Modal>
+  )
+}
+
+const stepStatuses = [
+  'current', 'error', 'pending', 'success',
+]
+
+Capture.propTypes = {
+  captureAmount: PropTypes.string,
+  isFromCheckout: PropTypes.bool.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  loading: PropTypes.bool,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onRetry: PropTypes.func.isRequired,
+  onViewTransaction: PropTypes.func.isRequired,
+  statusMessage: PropTypes.string,
+  stepStatus: PropTypes.shape({
+    identification: PropTypes.oneOf(stepStatuses),
+    confirmation: PropTypes.oneOf(stepStatuses),
+  }),
+  t: PropTypes.func.isRequired,
+  transaction: PropTypes.shape({
+    card: PropTypes.shape({
+      brand_name: PropTypes.string,
+      first_digits: PropTypes.string,
+      last_digits: PropTypes.string,
+    }),
+    customer: PropTypes.shape({
+      name: PropTypes.string,
+      email: PropTypes.string,
+    }),
+    payment: PropTypes.shape({
+      authorized_amount: PropTypes.number.isRequired,
+      installments: PropTypes.number,
+      paid_amount: PropTypes.number.isRequired,
+    }),
+  }).isRequired,
+}
+
+Capture.defaultProps = {
+  captureAmount: '0',
+  loading: false,
+  statusMessage: null,
+  stepStatus: {
+    identification: 'current',
+    confirmation: 'pending',
+  },
+}
+
+export default Capture

--- a/packages/pilot/stories/components/CaptureDetails/index.js
+++ b/packages/pilot/stories/components/CaptureDetails/index.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Card } from 'former-kit'
+
+import Section from '../../Section'
+import CaptureDetails from '../../../src/components/CaptureDetails'
+
+const contents = {
+  captureAmount: '10,00',
+  amount: '10,00',
+  cardBrand: 'Visa',
+  cardNumber: '4111 **** **** 1111',
+  customerEmail: 'johndoe@email.com',
+  customerName: 'John Doe',
+  installments: 1,
+}
+
+const labels = {
+  captureAmount: 'Valor a ser capturado',
+  amount: 'Valor autorizado',
+  cardBrand: 'Bandeira',
+  cardNumber: 'Número do cartão',
+  customerEmail: 'Email',
+  customerName: 'Nome',
+  installments: 'Número de parcelas',
+}
+
+const CaptureDetailsExample = () => (
+  <Section>
+    <Card>
+      <CaptureDetails
+        contents={contents}
+        labels={labels}
+      />
+    </Card>
+  </Section>
+)
+
+export default CaptureDetailsExample

--- a/packages/pilot/stories/components/index.js
+++ b/packages/pilot/stories/components/index.js
@@ -4,6 +4,7 @@ import { checkA11y } from '@storybook/addon-a11y'
 
 import BoletoRefundDetails from './BoletoRefundDetails'
 import ConfigurationCardForm from './ConfigurationCardForm'
+import CaptureDetails from './CaptureDetails'
 import CopyButton from './CopyButton'
 import CurrencyInput from './CurrencyInput'
 import CreditCardRefundDetails from './CreditCardRefundDetails'
@@ -44,6 +45,7 @@ storiesOf('Components|Custom components', module)
   .add('Event list', () => <EventList />)
   .add('DataDisplay', () => <DataDisplay />)
   .add('Reprocess details', () => <ReprocessDetails />)
+  .add('Capture Details', () => <CaptureDetails />)
   .add('TotalDisplay', () => <TotalDisplay />)
   .add('Payment card', () => <PaymentCards />)
   .add('RiskLevel', () => <RiskLevel />)

--- a/packages/pilot/stories/containers/Capture/Form/index.js
+++ b/packages/pilot/stories/containers/Capture/Form/index.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+
+import CaptureForm from '../../../../src/containers/Capture/Form'
+
+const CaptureFormExample = () => (
+  <CaptureForm
+    authorizedAmount={1000}
+    captureAmount="0"
+    cardBrand="Mastercard"
+    cardFirstDigits="41414"
+    cardLastDigits="4141"
+    isFromCheckout={false}
+    installments={1}
+    onConfirm={action('onConfirm')}
+    onChange={action('onChange')}
+    t={string => string}
+  />
+)
+
+const FixedCaptureFormExample = () => (
+  <CaptureForm
+    authorizedAmount={1000}
+    captureAmount="1000"
+    customerName="John Doe"
+    customerEmail="johndoe@pagar.me"
+    isFromCheckout
+    onConfirm={action('onConfirm')}
+    t={string => string}
+  />
+)
+
+export {
+  CaptureFormExample,
+  FixedCaptureFormExample,
+}

--- a/packages/pilot/stories/containers/Capture/Result/index.js
+++ b/packages/pilot/stories/containers/Capture/Result/index.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+
+import ErrorIcon from '../../../../src/components/TransferError/ErrorIcon.svg'
+import Result from '../../../../src/containers/Capture/Result'
+
+const CaptureResult = () => (
+  <Result
+    authorizedAmount={1000}
+    cardBrand="Mastercard"
+    cardFirstDigits="41414"
+    cardLastDigits="4141"
+    customerName="John Doe"
+    customerEmail="johndoe@pagar.me"
+    image={<ErrorIcon />}
+    installments={1}
+    message="Transação capturada com sucesso!"
+    onRetry={action('onRetry')}
+    onViewTransaction={action('onViewTransaction')}
+    paidAmount={1000}
+    status="current"
+    t={t => t}
+  />
+)
+
+export default CaptureResult

--- a/packages/pilot/stories/containers/Capture/index.js
+++ b/packages/pilot/stories/containers/Capture/index.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+
+import Capture from '../../../src/containers/Capture'
+
+const commonProps = {
+  captureAmount: '2000',
+  isFromCheckout: false,
+  isOpen: true,
+  onCancel: action('onCancel'),
+  onChange: action('onChange'),
+  onConfirm: action('onConfirm'),
+  onRetry: action('onRetry'),
+  onViewTransaction: action('viewTransaction'),
+  t: string => string,
+  transaction: {
+    capabilities: {
+      capturable: true,
+    },
+    card: {
+      brand_name: 'Mastercard',
+      first_digits: '4111',
+      last_digits: '1111',
+    },
+    payment: {
+      authorized_amount: 2000,
+      installments: 1,
+      paid_amount: 0,
+    },
+    customer: {
+      name: 'John Doe',
+      email: 'johndoe@email.com',
+    },
+  },
+}
+
+export default props => <Capture {...commonProps} {...props} />

--- a/packages/pilot/stories/containers/index.js
+++ b/packages/pilot/stories/containers/index.js
@@ -33,6 +33,12 @@ import {
   BoletoRefund,
   CreditCardRefund,
 } from './Refund'
+import Capture from './Capture'
+import {
+  CaptureFormExample,
+  FixedCaptureFormExample,
+} from './Capture/Form'
+import CaptureResult from './Capture/Result'
 import Reprocess from './Reprocess'
 import ReprocessForm from './Reprocess/Form'
 import ReprocessResult from './Reprocess/Result'
@@ -144,6 +150,49 @@ storiesOf('Containers|Page containers', module)
   ))
   .add('Balance', () => (
     <Balance />
+  ))
+  .add('Capture form', () => (
+    <CaptureFormExample />
+  ))
+  .add('Capture form with fixed amount', () => (
+    <FixedCaptureFormExample />
+  ))
+  .add('Capture confirmation', () => (
+    <CaptureResult />
+  ))
+  .add('Capture step identification', () => (
+    <Capture
+      stepStatus={{
+        identification: 'current',
+        confirmation: 'pending',
+      }}
+    />
+  ))
+  .add('Capture step identification (token)', () => (
+    <Capture
+      isFromCheckout
+      stepStatus={{
+        identificaiton: 'current',
+        confirmation: 'pending',
+      }}
+    />
+  ))
+  .add('Capture step confirmation', () => (
+    <Capture
+      stepStatus={{
+        identification: 'success',
+        confirmation: 'current',
+      }}
+    />
+  ))
+  .add('Capture step confirmation error', () => (
+    <Capture
+      stepStatus={{
+        identification: 'success',
+        confirmation: 'error',
+      }}
+      statusMessage="An error ocurred!"
+    />
   ))
   .add('Reprocess form', () => (
     <ReprocessForm />


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
Este PR adiciona o modal para captura de transações. A ideia é que seja possível capturar ambas as transações criadas pelo Checkout (Encryption Key) como aquelas criadas diretamente pela API (API Key). Sendo as distinções dos comportamentos:
- Encryption Key: Valor não pode ser alterado, pois este é aplicado no frontend com o uso do Checkout (a nossa API também não permite capturar um valor diferente do autorizado pelo front).
- API Key: Permitir que o usuário informe o valor a ser capturado, sendo possível fazer a captura parcial.

relacionado a issue #869

## Checklist
- [x] Modal de captura com opção para valor fixado ou editável

## Screenshots

- Captura editável (API Key)

![image](https://user-images.githubusercontent.com/18339615/45270835-ef146800-b477-11e8-9d57-2ff7a2dd6ddf.png)

- Captura não editável (Encryption Key)

![image](https://user-images.githubusercontent.com/18339615/45270854-300c7c80-b478-11e8-973d-7474c17db927.png)

- Sucesso

![image](https://user-images.githubusercontent.com/18339615/45270859-3bf83e80-b478-11e8-87de-a71a6f26ff4d.png)

### Layout:

- Layout de captura editável

![image](https://user-images.githubusercontent.com/18339615/45270838-fb002a00-b477-11e8-9e4e-df6c6adee260.png)

- Layout de captura não editável

![image](https://user-images.githubusercontent.com/18339615/45270849-123f1780-b478-11e8-9fca-675199684edc.png)

- Layout de captura bem sucedida

![image](https://user-images.githubusercontent.com/18339615/45270941-0d2e9800-b479-11e8-888e-beb439b4bad4.png)
