### PR TITLE
Ajuste na configuração de variáveis de ambiente usadas no deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,8 @@ jobs:
           cd pilot-latest-live
           export PUBLIC_URL_REGEX='https:\/\/beta.dashboard.stg.pagarme.net\/latest'
           export PUBLIC_URL='https://beta.dashboard.stg.pagarme.net/latest'
-          export REACT_APP_LIVE_URL='https://beta.dashboard.stg.pagarme.net/latest'
-          export REACT_APP_TEST_URL='https://beta.dashboard.sandbox.stg.pagarme.net/latest'
+          export REACT_APP_LIVE_URL='https://beta.dashboard.stg.pagarme.net/latest/'
+          export REACT_APP_TEST_URL='https://beta.dashboard.sandbox.stg.pagarme.net/latest/'
           export REACT_APP_API_ENVIRONMENT='live'
           sed -e 's/\".\"/"'$PUBLIC_URL_REGEX'\"/g' package.json > package.json.bak
           cp package.json.bak package.json
@@ -81,8 +81,8 @@ jobs:
           cd ../pilot-${CIRCLE_TAG}-live
           export PUBLIC_URL_REGEX='https:\/\/beta.dashboard.stg.pagarme.net\/versions\/'${CIRCLE_TAG}
           export PUBLIC_URL='https://beta.dashboard.stg.pagarme.net/versions/'${CIRCLE_TAG}
-          export REACT_APP_LIVE_URL='https://beta.dashboard.stg.pagarme.net/versions/'${CIRCLE_TAG}
-          export REACT_APP_TEST_URL='https://beta.dashboard.sandbox.stg.pagarme.net/versions/'${CIRCLE_TAG}
+          export REACT_APP_LIVE_URL='https://beta.dashboard.stg.pagarme.net/versions/${CIRCLE_TAG}/'
+          export REACT_APP_TEST_URL='https://beta.dashboard.sandbox.stg.pagarme.net/versions/${CIRCLE_TAG}/'
           export REACT_APP_API_ENVIRONMENT='live'
           sed -e 's/\".\"/"'$PUBLIC_URL_REGEX'\"/g' package.json > package.json.bak
           cp package.json.bak package.json
@@ -132,8 +132,8 @@ jobs:
           cd pilot-live
           export PUBLIC_URL_REGEX='https:\/\/beta.dashboard.pagar.me'
           export PUBLIC_URL='https://beta.dashboard.pagar.me'
-          export REACT_APP_LIVE_URL='https://beta.dashboard.pagar.me'
-          export REACT_APP_TEST_URL='https://beta.dashboard.sandbox.pagar.me'
+          export REACT_APP_LIVE_URL='https://beta.dashboard.pagar.me/'
+          export REACT_APP_TEST_URL='https://beta.dashboard.sandbox.pagar.me/'
           export REACT_APP_API_ENVIRONMENT='live'
           sed -e 's/\".\"/"'$PUBLIC_URL_REGEX'\"/g' package.json > package.json.bak
           cp package.json.bak package.json

--- a/packages/pilot/src/environment.js
+++ b/packages/pilot/src/environment.js
@@ -8,9 +8,8 @@ const {
 
 const getLiveUrl = defaultTo('https://beta.dashboard.stg.pagarme.net/latest/index.html')
 const getTestUrl = defaultTo('https://beta.dashboard.sandbox.stg.pagarme.net/latest/index.html')
-const getEnv = defaultTo('test')
 
-const env = getEnv(REACT_APP_API_ENVIRONMENT)
+const env = REACT_APP_API_ENVIRONMENT === 'live' ? 'live' : 'test'
 const liveUrl = getLiveUrl(REACT_APP_LIVE_URL)
 const testUrl = getTestUrl(REACT_APP_TEST_URL)
 


### PR DESCRIPTION
## Contexto
Este PR corrige as variáveis `REACT_APP_LIVE_URL` e `REACT_APP_TEST_URL`, atualmente estas variáveis não possuem uma `/` (barra) no final. Isso causa um redirecionamento incorreto.
Alem disso este PR tambem corrige a atribuição da variável `environment`no código para que ela sempre possua os valores `live` ou `test`. Estes problemas foram identificados na publicação da release `v0.6.0-rc1`

## Checklist
- [x] correção das variáveis `REACT_APP_LIVE_URL` e `REACT_APP_TEST_URL` no `config.yml` do Circle CI
- [x] correção da atribuição da variável de ambiente `environment`

## Screenshots
este PR não tem impacto visual

## Notas de deploy
este PR modifica os valores atribuidos as variaveis de ambiente  `REACT_APP_LIVE_URL` e `REACT_APP_TEST_URL`