### PR TITLE
self-register: fix translate message

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -612,12 +612,12 @@
         "trade_name": "Nome fantasia"
       },
       "create_account": {
-        "attraction": "Crie sua conta e aceite pagamentos online hoje!",
+        "attraction": "Crie sua conta e aceite pagamentos online hoje.",
         "confirm_password": "Confirmar a senha",
         "continue": "Continuar",
         "email": "E-mail",
         "password": "Senha",
-        "welcome": "Boas vindas ao Pagar.me!"
+        "welcome": "Boas-vindas ao Pagar.me!"
       },
       "different_passwords_error": "As senhas não conferem",
       "number_error": "Deve ser um número",


### PR DESCRIPTION
## Contexto
- Corrige um erro de português em `Boas-vindas`
- Troca a exclamação por ponto final no subtitle

## Issues linkadas
- [ ] Resolves https://github.com/pagarme/gatekeepers/issues/597

## Screenshots
![image](https://user-images.githubusercontent.com/9501115/46590380-2da63e00-ca89-11e8-89f1-a8fdb4b43288.png)

### Layout:
[insira o screenshot aqui]
<!-- Insira o layout do Zeplin des