### PR TITLE
Filter: update spacing and flexbox

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -977,7 +977,7 @@
       "period_full": "Todo período",
       "period_today": "Hoje",
       "period": "{{start}} - {{end}}",
-      "text_search_placeholder": "ID, número do documento, nome ou e-mail do cliente",
+      "text_search_placeholder": "Filtre por Id, número do documento, nome ou e-mail",
       "title": "Transações",
       "total_amount": "total de",
       "try_again": "Tente novamente com outros filtros."
@@ -1001,7 +1001,7 @@
     },
     "filter": {
       "apply": "Filtrar",
-      "reset": "Limpar",
+      "reset": "Limpar filtros",
       "more": "Mais filtros",
       "filtering_by": "Filtrando por"
     },

--- a/packages/pilot/src/containers/Filter/index.js
+++ b/packages/pilot/src/containers/Filter/index.js
@@ -91,6 +91,7 @@ class Filters extends Component {
 
   renderChildrenInput (input, index) {
     return React.cloneElement(input, {
+      className: style.search,
       disabled: this.props.disabled,
       key: `${input.props.name}-${index}`,
     })
@@ -130,7 +131,7 @@ class Filters extends Component {
             {t('components.filter.more')}
           </Button>
         }
-        <Spacing size="large" />
+        <Spacing size="flex" />
         <Button
           relevance={filtersChanged ? 'normal' : 'low'}
           onClick={onClear}

--- a/packages/pilot/src/containers/Filter/style.css
+++ b/packages/pilot/src/containers/Filter/style.css
@@ -5,6 +5,10 @@
   overflow: initial;
 }
 
+.search {
+  min-width: 380px;
+}
+
 .selectedOptionsTitle {
   font-size: 14px;
   text-transform: uppercase;


### PR DESCRIPTION
## Contexto
Espaço entre itens do filtro. Esse PR depende de uma modificação no espaço entre `.actions` de cards e nas cores de placeholder de input em: https://github.com/pagarme/former-kit-skin-pagarme/pull/146

**Depends on https://github.com/pagarme/former-kit-skin-pagarme/pull/150** 

## Checklist
- [x] As fontes estão com cores diferentes no placeholder do input. Mudar para #757575
- [x] As fontes nos inputs devem ter tamanho 14px
- [x] Espaço: distância entre os itens dos filtros é de 16px. Entre o botão "mais filtros" e "limpar filtros"/"filtrar" é dinâmico via Flexbox.

## Issues linkadas
- [x] Resolves #743

### Layout:
![image](https://user-images.githubusercontent.com/20358128/46638673-681ae400-cb38-11e8-93b4-cebd77c54fa2.png)
`zeplin`: https://zpl.io/VK0ZzR7

### Preview:
![image](https://user-images.githubusercontent.com/20358128/46638891-7ddcd900-cb39-11e8-8871-25274568caa8.png)

