### PR TITLE
Modal: refatorando o flow da animação do modal

### DIFF
--- a/packages/pilot/src/containers/Settings/Company/TeamInfoTab/TeamManagement/index.js
+++ b/packages/pilot/src/containers/Settings/Company/TeamInfoTab/TeamManagement/index.js
@@ -62,16 +62,14 @@ class MenagementTeam extends React.Component {
     const { loadingCreateUser } = this.state
     return (
       <Fragment>
-        {this.state.isModalOpened &&
-          <AddNewUserModal
-            isOpen={this.state.isModalOpened}
-            handleCloseModal={this.handleCloseModal}
-            handleCreateUser={this.props.handleCreateUser}
-            status={createUserStatus}
-            loading={loadingCreateUser}
-            t={t}
-          />
-        }
+        <AddNewUserModal
+          isOpen={this.state.isModalOpened}
+          handleCloseModal={this.handleCloseModal}
+          handleCreateUser={this.props.handleCreateUser}
+          status={createUserStatus}
+          loading={loadingCreateUser}
+          t={t}
+        />
         <CardActions>
           <Button
             size="default"

--- a/packages/pilot/src/pages/Refund/Refund.js
+++ b/packages/pilot/src/pages/Refund/Refund.js
@@ -283,7 +283,7 @@ Refund.propTypes = {
   onSuccess: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   transaction: PropTypes.shape({
-    id: PropTypes.number.isRequired,
+    id: PropTypes.number,
   }).isRequired,
 }
 

--- a/packages/pilot/src/pages/Reprocess/index.js
+++ b/packages/pilot/src/pages/Reprocess/index.js
@@ -53,7 +53,7 @@ class Reprocess extends Component {
       error: null,
       loading: false,
       stepStatus: reprocessStepStatuses.confirmation,
-      transaction: props.transaction,
+      transaction: null,
     }
     this.handleClose = this.handleClose.bind(this)
     this.handleConfirm = this.handleConfirm.bind(this)
@@ -63,9 +63,11 @@ class Reprocess extends Component {
     this.requestData = this.requestData.bind(this)
   }
 
-  componentDidMount () {
-    if (isEmptyOrNull(this.state.transaction)
-      && isEmptyOrNull(this.props.transaction)) {
+  componentDidUpdate (prevProps) {
+    const { isOpen } = this.props
+    if (isOpen
+      && prevProps.isOpen !== isOpen
+      && isEmptyOrNull(this.state.transaction)) {
       this.requestData()
     }
   }
@@ -82,10 +84,10 @@ class Reprocess extends Component {
 
     client.transactions
       .details(transactionId)
-      .then(({ result }) => {
+      .then(({ transaction }) => {
         this.setState({
           loading: false,
-          transaction: result,
+          transaction,
         })
       })
       .catch((error) => {
@@ -161,7 +163,10 @@ class Reprocess extends Component {
   }
 
   render () {
-    const { t } = this.props
+    const {
+      isOpen,
+      t,
+    } = this.props
     const {
       error,
       loading,
@@ -175,9 +180,9 @@ class Reprocess extends Component {
 
     return (
       <Fragment>
-        {!isEmpty(transaction) &&
+        {!isNil(transaction) &&
           <ReprocessContainer
-            isOpen
+            isOpen={isOpen}
             loading={loading}
             onCancel={this.handleClose}
             onConfirm={this.handleConfirm}
@@ -206,31 +211,12 @@ Reprocess.propTypes = {
     replace: PropTypes.func,
   }).isRequired,
   onClose: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired,
   t: PropTypes.func.isRequired,
-  transaction: PropTypes.shape({
-    amount: PropTypes.number,
-    card: PropTypes.shape({
-      first_digits: PropTypes.string.isRequired,
-      holder_name: PropTypes.string.isRequired,
-      last_digits: PropTypes.string.isRequired,
-    }),
-    id: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.string,
-    ]),
-    payment: PropTypes.shape({
-      installments: PropTypes.number.isRequired,
-    }),
-  }),
   transactionId: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
   ]).isRequired,
 }
-
-Reprocess.defaultProps = {
-  transaction: null,
-}
-
 
 export default enhanced(Reprocess)

--- a/packages/pilot/src/pages/Transactions/Details/Details.js
+++ b/packages/pilot/src/pages/Transactions/Details/Details.js
@@ -468,20 +468,18 @@ class TransactionDetails extends Component {
             transactionId={transaction.id}
           />
         }
-        {showRefund &&
-          <Refund
-            isOpen={showRefund}
-            onClose={this.handleCloseRefund}
-            onSuccess={this.handleUpdate}
-            transaction={transaction}
-          />}
-        {showReprocess &&
-          <Reprocess
-            onClose={this.handleReprocessClose}
-            transactionId={id}
-            transaction={transaction}
-          />
-        }
+        <Refund
+          isOpen={showRefund}
+          onClose={this.handleCloseRefund}
+          onSuccess={this.handleUpdate}
+          transaction={transaction}
+        />
+        <Reprocess
+          isOpen={showReprocess}
+          onClose={this.handleReprocessClose}
+          transactionId={id}
+          transaction={transaction}
+        />
       </Fragment>
     )
   }


### PR DESCRIPTION
## Contexto
Esse PR refatora alguns componentes para aparecer a transição de saída ao fechar o modal. Como alguns componentes tinham validação e sumiam do DOM rapidamente, tive que refatorar para aparecer que o `closeTimeoutMS` acontecesse. Esse PR é relacionado com https://github.com/pagarme/former-kit-skin-pagarme/pull/148 e https://github.com/pagarme/former-kit/pull/204. 

## Checklist
- [x] Remover validações para exibição do componete de AddNewUserModal/Refund/Reprocess. Visto que o modal é removido do DOM antes da animação de fechar ser exibida caso exista a validação.
- [x] ID de transaction do Refund não ser obrigatório
- [x] Remover transaction de Reprocess, adicionar `isOpen` e faz com que a `requestData` seja disparada quando a Modal for aberta

## Issues linkadas
- [x] Resolves #858 

## Como testar
- Vá para a branch `master` em former-kit-skin e former-kit
```
git checkout master
```
- Crie um link para os repositórios former-kit-skin e former-kit
```
yarn link
```

- Dê um link dentro do former-kit-skin-pagarme
```
yarn link former-kit
```

- Dê um link dentro da Pilot
```
yarn link former-kit
yarn link former-kit-skin
```

- Rode normalmente o storybook da former-kit e/ou da Pilot
```
yarn storybook
```
