### PR TITLE
create-company: remove should_activate parameter

### DIFF
--- a/packages/cockpit/src/company/register/index.js
+++ b/packages/cockpit/src/company/register/index.js
@@ -11,7 +11,6 @@ import {
   propEq,
   reverse,
   split,
-  T,
   unless,
 } from 'ramda'
 import { apiUrl } from '../../environment'
@@ -51,7 +50,6 @@ const buildCompanyParameters = applySpec({
   company_template_token: always('cjkifh2ja0000y0739q5odyyt'),
   email: prop('email'),
   name: prop('tradeName'),
-  should_activate: T,
   password: prop('password'),
   full_name: prop('legalName'),
   document_type: getDocumentType,


### PR DESCRIPTION
## Contexto

Estamos removendo o parâmetro `should_activate` na request que o cockpit envia pois não usamos na API

## Issues linkadas
- [x] https://github.com/pagarme/gatekeepers/issues/622
