### PR TITLE
create-transaction: add payment credit card form

### DIFF
--- a/packages/pilot/src/containers/CreateTransaction/Payment/CreditCard.js
+++ b/packages/pilot/src/containers/CreateTransaction/Payment/CreditCard.js
@@ -1,0 +1,146 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Form from 'react-vanilla-form'
+import {
+  CardContent,
+  CardSection,
+  CardTitle,
+  Checkbox,
+  Col,
+  FormDropdown,
+  FormInput,
+  Row,
+} from 'former-kit'
+
+import isCVV from '../../../validation/cvv'
+import isCreditCard from '../../../validation/creditCard'
+import isRequired from '../../../validation/required'
+import isFutureDate from '../../../validation/sameOrFutureDate'
+
+import style from './style.css'
+
+const validations = t => ({
+  cvv: [isRequired(t('required')), isCVV('cvv_invalid')],
+  expirationDate: [
+    isRequired(t('required')),
+    isFutureDate(t('date_invalid'), {
+      format: 'MM/YY',
+      period: 'month',
+    }),
+  ],
+  holderName: isRequired(t('required')),
+  installments: isRequired(t('required')),
+  cardNumber: [
+    isRequired(t('required')),
+    isCreditCard(t('credit_card_invalid')),
+  ],
+})
+
+const CreditCard = ({
+  data,
+  installmentsOptions,
+  onChange,
+  onChangeCapture,
+  onChangeWithMask,
+  t,
+}) => (
+  <CardSection>
+    <CardTitle title={t('add_transaction_payment_title')} />
+
+    <CardContent>
+      <Form
+        data={data}
+        onChange={onChange}
+        validation={validations(t)}
+        validateOn="blur"
+      >
+        <Row>
+          <Col tablet={10} desk={10}>
+            <FormInput
+              name="holderName"
+              label={t('add_transaction_payment_holder_name')}
+            />
+          </Col>
+        </Row>
+
+        <Row>
+          <Col tablet={6} desk={6}>
+            <FormInput
+              label={t('add_transaction_payment_card_number')}
+              mask="1111 1111 1111 1111 1111"
+              name="cardNumber"
+              onChange={onChangeWithMask('cardNumber')}
+            />
+          </Col>
+
+          <Col tablet={2} desk={2} className={style.fields}>
+            <FormInput
+              label={t('add_transaction_payment_expiration')}
+              mask="11/11"
+              name="expirationDate"
+              onChange={onChangeWithMask('expirationDate')}
+            />
+          </Col>
+
+          <Col tablet={2} desk={2} className={style.fields}>
+            <FormInput
+              label={t('add_transaction_payment_cvv')}
+              mask="1111"
+              name="cvv"
+              onChange={onChangeWithMask('cvv')}
+            />
+          </Col>
+        </Row>
+
+        <Row>
+          <Col tablet={6} desk={6}>
+            <FormDropdown
+              name="installments"
+              options={installmentsOptions}
+              label={t('add_transaction_payment_installments')}
+            />
+          </Col>
+
+          <Col tablet={6} desk={6}>
+            <FormInput
+              name="description"
+              label={t('add_transaction_payment_description')}
+            />
+          </Col>
+        </Row>
+
+        <Row>
+          <Checkbox
+            label={t('add_transaction_payment_capture')}
+            name="capture"
+            value="capture"
+            onChange={onChangeCapture}
+            checked={data.capture}
+          />
+        </Row>
+      </Form>
+    </CardContent>
+  </CardSection>
+)
+
+CreditCard.propTypes = {
+  data: PropTypes.shape({
+    cvv: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    expirationDate: PropTypes.string.isRequired,
+    holderName: PropTypes.string.isRequired,
+    installments: PropTypes.string.isRequired,
+    cardNumber: PropTypes.string.isRequired,
+    capture: PropTypes.bool.isRequired,
+  }).isRequired,
+  installmentsOptions: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })).isRequired,
+  onChange: PropTypes.func.isRequired,
+  onChangeCapture: PropTypes.func.isRequired,
+  onChangeWithMask: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired,
+}
+
+export default CreditCard

--- a/packages/pilot/src/containers/CreateTransaction/Payment/style.css
+++ b/packages/pilot/src/containers/CreateTransaction/Payment/style.css
@@ -1,0 +1,7 @@
+.fields {
+
+  & div,
+  & input {
+    max-width: 100%;
+  }
+}

--- a/packages/pilot/src/validation/creditCard.js
+++ b/packages/pilot/src/validation/creditCard.js
@@ -1,0 +1,4 @@
+import isCreditCard from 'validator/lib/isCreditCard'
+
+export default message => value =>
+  !isCreditCard(value.replace(/[_]+/, '')) && message

--- a/packages/pilot/src/validation/cvv.js
+++ b/packages/pilot/src/validation/cvv.js
@@ -1,0 +1,2 @@
+const cvv = /^\d{3,4}[_]?$/
+export default message => value => !cvv.test(value) && message

--- a/packages/pilot/src/validation/sameOrFutureDate.js
+++ b/packages/pilot/src/validation/sameOrFutureDate.js
@@ -1,0 +1,4 @@
+import moment from 'moment'
+
+export default (message, { format = 'DD/MM/YYYY', period = 'day' }) => date =>
+  !moment(date, format).isSameOrAfter(moment(), period) && message

--- a/packages/pilot/stories/components/CreditCardForm/index.js
+++ b/packages/pilot/stories/components/CreditCardForm/index.js
@@ -1,0 +1,83 @@
+import React, { Component } from 'react'
+import { Card } from 'former-kit'
+import { action } from '@storybook/addon-actions'
+
+import Section from '../../Section'
+import CreditCardForm from '../../../src/containers/CreateTransaction/Payment/CreditCard'
+
+const actionChange = action('change')
+
+const setStateData = (name, { value }) =>
+  ({ creditCard }) => ({
+    creditCard: {
+      ...creditCard,
+      [name]: value,
+    },
+  })
+
+class CreditCard extends Component {
+  constructor () {
+    super()
+
+    this.state = {
+      creditCard: {
+        capture: true,
+        cardNumber: '',
+        cvv: '',
+        expirationDate: '',
+        holderName: '',
+        installments: '',
+      },
+    }
+
+    this.handleChange = this.handleChange.bind(this)
+    this.handleChangeCapture = this.handleChangeCapture.bind(this)
+    this.handleChangeWithMask = this.handleChangeWithMask.bind(this)
+  }
+
+  handleChange (data) {
+    this.setState({
+      creditCard: data,
+    }, () => actionChange(this.state.creditCard))
+  }
+
+  handleChangeWithMask (name) {
+    return ({ target }) => this.setState(setStateData(name, target))
+  }
+
+  handleChangeCapture () {
+    const { creditCard } = this.state
+
+    this.setState({
+      creditCard: {
+        ...creditCard,
+        capture: !creditCard.capture,
+      },
+    })
+  }
+
+  render () {
+    const { creditCard } = this.state
+
+    return (
+      <Section>
+        <Card>
+          <CreditCardForm
+            data={creditCard}
+            installmentsOptions={[
+              { name: '1x sem juros', value: '1' },
+              { name: '2x sem juros', value: '2' },
+              { name: '3x sem juros', value: '3' },
+            ]}
+            onChange={this.handleChange}
+            onChangeWithMask={this.handleChangeWithMask}
+            onChangeCapture={this.handleChangeCapture}
+            t={t => t}
+          />
+        </Card>
+      </Section>
+    )
+  }
+}
+
+export default CreditCard

--- a/packages/pilot/stories/components/index.js
+++ b/packages/pilot/stories/components/index.js
@@ -8,6 +8,7 @@ import ConfigurationCardForm from './ConfigurationCardForm'
 import CopyButton from './CopyButton'
 import CurrencyInput from './CurrencyInput'
 import CreditCardRefundDetails from './CreditCardRefundDetails'
+import CreditCardForm from './CreditCardForm'
 import CustomerSelection from './CustomerSelection'
 import CustomerCard from './CustomerCard'
 import DataDisplay from './DataDisplay'
@@ -37,7 +38,7 @@ import Message from './Message'
 import MessageActions from './MessageActions'
 import Quantity from './QuantityInput'
 
-storiesOf('Components|Add Transaction/Customer', module)
+storiesOf('Components|Add Transaction/Customers', module)
   .addDecorator(checkA11y)
   .add('Customer form', () => <CustomerForm />)
   .add('Customer selection', () => <CustomerSelection />)
@@ -48,9 +49,9 @@ storiesOf('Components|Add Transaction/Products', module)
   .add('List products', () => <WithProducts />)
   .add('Empty list products', () => <EmptyList />)
 
-storiesOf('Components|Quantity', module)
+storiesOf('Components|Add Transaction/Payment', module)
   .addDecorator(checkA11y)
-  .add('Quantity', () => <Quantity />)
+  .add('Credit card form', () => <CreditCardForm />)
 
 storiesOf('Components|Custom components', module)
   .addDecorator(checkA11y)
@@ -83,3 +84,4 @@ storiesOf('Components|Custom components', module)
   .add('Message', () => <Message />)
   .add('Message with actions', () => <MessageActions />)
   .add('TotalDisplay', () => <TotalDisplay />)
+  .add('Quantity', () => <Quantity />)


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
Este PR adiciona o formulário de cartão de crédito no step de pagamentos em adicionar transação.

## Checklist
- [x] Deve validar os campos: **holderName**, **cardNumber**, **expirationDate**, **cvv** e **installments**
- [x] Deve validar o formato do campo **cvv**.
- [x] Deve permitir selecionar em uma lista o número de parcelas.
- [x] Deve aplicar uma máscara em **cardNumber** e **expirationDate**

## Issues linkadas
- [x] Resolves #956 

## Screenshots
![screenshot from 2018-10-19 12-08-59](https://user-images.githubusercontent.com/6943919/47227329-f133e580-d398-11e8-8a75-fa89daa23d76.png)

### Layout:
![screenshot from 2018-10-19 12-06-51](https://user-images.githubusercontent.com/6943919/47227335-f5f89980-d398-11e8-9e04-80ca4eae3f10.png)

## Como testar
- Faça checkout para esta branch `git checkout add/transaction-payment-credit-form`
- Rode o storybook: `yarn storybook`