### PR TITLE
self-register: add feature flag to enable self register route

### DIFF
--- a/packages/pilot/src/pages/Root.js
+++ b/packages/pilot/src/pages/Root.js
@@ -87,12 +87,16 @@ class Root extends Component {
     }
 
     if (!client) {
-      return (
-        <Switch>
-          <Route path="/account/register" component={SelfRegister} />
-          <Route path="/account" component={Account} />
-        </Switch>
-      )
+      if (localStorage.getItem('feature_flag_self_register') === 'true') {
+        return (
+          <Switch>
+            <Route path="/account/register" component={SelfRegister} />
+            <Route path="/account" component={Account} />
+          </Switch>
+        )
+      }
+
+      return <Route path="/account" component={Account} />
     }
 
     if (user && startsWith('/account/login', path)) {


### PR DESCRIPTION
## Contexto
Adiciona a feature flag na rota `/account/register`, habilitando-a somente caso tenha no local storage `feature_flag_self_register` como `'true'`.

Para ativar, basta inserir no console:
```js
localStorage.setItem('feature_flag_self_register', 'true')
```

## Checklist
- [x] Adição da feature flag para a `self register`

## Issues linkadas
- [x] Resolves https://github.com/pagarme/gatekeepers/issues/639
