### PR TITLE
Recipients: Adicionar busca pelo external_id

### DIFF
--- a/packages/pilot/src/pages/Recipients/Search/Search.js
+++ b/packages/pilot/src/pages/Recipients/Search/Search.js
@@ -17,7 +17,6 @@ import {
   isNil,
   juxt,
   mergeAll,
-  of,
   path,
   pipe,
   replace,
@@ -93,7 +92,7 @@ const isRecipientId = (recipientText) => {
   return recipientPattern.test(recipientText)
 }
 
-const isBanckAccount = (bankAccount) => {
+const isBankAccount = (bankAccount) => {
   const bankNumber = Number.parseInt(bankAccount, 10)
   return Number.isInteger(bankNumber)
 }
@@ -176,26 +175,54 @@ class RecipientsSearch extends React.Component {
 
   requestData (query) {
     this.props.onRequestSearch({ query })
-    const searchQuery = {}
-    let key = 'name'
 
-    if (query && query.search) {
-      if (isRecipientId(query.search)) {
-        key = 'id'
-      } else if (isBanckAccount(query.search)) {
-        key = 'bank_account_id'
+    const findByQuery = ({ search, count, offset }) => {
+      let key = 'name'
+
+      if (search) {
+        if (isRecipientId(search)) {
+          key = 'id'
+        } else if (isBankAccount(search)) {
+          key = 'bank_account_id'
+        }
       }
 
-      searchQuery[key] = query.search
+      return this.props.client
+        .recipients
+        .find({
+          [key]: search,
+          count,
+          page: offset,
+        })
+        .then(recipients => [recipients])
+        .catch((error) => {
+          this.props.onRequestSearchFail(error)
+        })
     }
 
-    searchQuery.count = query.count
-    searchQuery.page = query.offset
+    const findByExternalId = ({ search, offset, count }) => {
+      if (search &&
+          !isRecipientId(search)) {
+        return this.props.client
+          .recipients
+          .find({
+            count,
+            external_id: search,
+            page: offset,
+          })
+          .catch((error) => {
+            this.props.onRequestSearchFail(error)
+          })
+      }
 
-    return this.props.client
-      .recipients
-      .find(searchQuery)
-      .then(res => flatten(of(res)))
+      return Promise.resolve([])
+    }
+
+    return Promise.all([
+      findByExternalId(query),
+      findByQuery(query),
+    ])
+      .then(res => flatten(res))
       .then((res) => {
         const result = {
           total: {


### PR DESCRIPTION
## Contexto
Foi adicionado no Recebedor um campo denominado `external_id`, com isso a Tela de Listagem de Recebedores deverá ser capaz de fazer busca pelo `external_id`

O Campo `external_id` não tem padrão, ou seja, é um campo livre, assim dificulta a identificação para realizar as buscas, pois como os Recebedores não são indexado pelo `Elastic Search` é necessário discriminar onde deve ser buscado.

Hoje os campos de `id` e `bankAccount` são identificados seguindo o padrão de como eles são gerados (ex: começar com `re_` ou ser apenas números) no caso do `external_id` a solução será: caso não caia em nenhum dos cases, realizar a busca tanto no `name` quanto no `external_id`, assim retornando o resultado dos dois.

## Checklist
- [X] Manter o comportamento atual
- [X] Adicionar a busca de 'external_id`
