### PR TITLE
Captura manual - Adiciona link para a documentação

### DIFF
--- a/packages/pilot/src/containers/Capture/Form/index.js
+++ b/packages/pilot/src/containers/Capture/Form/index.js
@@ -117,7 +117,7 @@ const CaptureForm = ({
                 <span className={style.captureWarning}>
                   {t('pages.capture.token_capture_warning')}
                   {' '}
-                  <a href="https://gist.github.com/vagnervst/781adafc855fd9a51a94417731d9fe2f">
+                  <a href="https://docs.pagar.me/v3/docs/captura-manual-de-transa%C3%A7%C3%B5es-criadas-pelo-checkout-pagarme">
                     {t('pages.capture.token_capture_link')}
                   </a>
                 </span>


### PR DESCRIPTION
## Contexto
Como a captura manual de transações criadas pelo Checkout Pagar.me necessita de atenção à alguns detalhes, criei uma página na documentação para fornecer mais detalhes ao cliente.

## Checklist
- [x] Adiciona um link para uma página oculta em nossa documentação

## Issues linkadas
- [x] Resolves #869

## Screenshots

### Preview:
![image](https://user-images.githubusercontent.com/18339615/51258170-7f1b6e80-1990-11e9-88c3-f870a2d894a3.png)