### PR TITLE
Transactions: Order status legend

### DIFF
--- a/packages/cockpit/src/transactions/search/statusOrder.js
+++ b/packages/cockpit/src/transactions/search/statusOrder.js
@@ -1,0 +1,18 @@
+const status = [
+  'waiting_payment',
+  'authorized',
+  'cancelled',
+  'chargedback',
+  'chargedback_refund',
+  'analyzing',
+  'refunded',
+  'pending_refund',
+  'unavailable',
+  'paid',
+  'processing',
+  'refused',
+  'pending_review',
+  'suspended',
+]
+
+export default status


### PR DESCRIPTION
## Contexto
A ordenação das legendas das transações estava sendo feita de acordo com o nome do status em inglês. Esse PR corrige esse problema ordenando as legendas para PT-BR.

**Esse PR só resolve a parte de Front-end da ordenação, levando os itens de <TransactionSearch> estarem sempre ordenados por ordem alfabética na página, e não por completo. O fix completo deveria ser na API.**

## Checklist
- [x] Ordenação em PT-BR na página de Transações

## Issues linkadas
- [x] Resolves https://github.com/pagarme/pilot/issues/974

## Screenshots
<img width="422" alt="screen shot 2019-03-06 at 19 14 53" src="https://user-images.githubusercontent.com/20358128/53917814-3143ee00-4044-11e9-93d0-29078957015d.png">

## Como testar?
- Rode a Pilot em `packages/pilot`
```
yarn start
```
- Filtre os resultados para ordem crescente ou decrescente dentro da página de Transações e veja se está indo em ordem alfabética em PT-BR.
