### PR TITLE
Fix/recipient issues

### DIFF
--- a/packages/cockpit/src/recipient/add/mocks/afterFormat.json
+++ b/packages/cockpit/src/recipient/add/mocks/afterFormat.json
@@ -10,7 +10,7 @@
     "legal_name": "Default",
     "type": "conta_corrente"
   },
-  "transfer_day": "5",
+  "transfer_day": "1",
   "transfer_enabled": true,
   "transfer_interval": "weekly"
 }

--- a/packages/cockpit/src/recipient/add/mocks/beforeFormat.json
+++ b/packages/cockpit/src/recipient/add/mocks/beforeFormat.json
@@ -12,10 +12,9 @@
     "anticipationDays": "15",
     "anticipationModel": "manual",
     "anticipationVolumePercentage": "100",
-    "transferDay": "5",
+    "transferDay": "1",
     "transferEnabled": true,
-    "transferInterval": "weekly",
-    "transferWeekday": "tuesday"
+    "transferInterval": "weekly"
   },
   "identification": {
     "cnpj": "",

--- a/packages/cockpit/src/recipient/add/recipientBuilders.js
+++ b/packages/cockpit/src/recipient/add/recipientBuilders.js
@@ -58,16 +58,8 @@ export const formatToTransfer = (data) => {
   recipientTransferData.transfer_enabled = data.configuration.transferEnabled
 
   if (data.configuration.transferInterval === 'weekly') {
-    const weekDayNumberMap = {
-      monday: '1',
-      tuesday: '2',
-      wednesday: '3',
-      thursday: '4',
-      friday: '5',
-    }
-    const weekDay = data.configuration.transferWeekday
-    const transferDay = weekDayNumberMap[weekDay]
-    recipientTransferData.transfer_day = transferDay
+    const weekDay = data.configuration.transferDay
+    recipientTransferData.transfer_day = weekDay
   }
 
   if (data.configuration.transferInterval === 'daily') {

--- a/packages/cockpit/src/recipient/detail/format/formatRecipient.js
+++ b/packages/cockpit/src/recipient/detail/format/formatRecipient.js
@@ -51,14 +51,13 @@ export function formatTransferData (data) {
     transferDay: data.transfer_day.toString(),
     transferEnabled: data.transfer_enabled,
     transferInterval: data.transfer_interval,
-    transferWeekday: '',
   }
 
   if (data.transfer_interval === 'daily') {
     transfer.transferDay = '0'
   }
   if (data.transfer_interval === 'weekly') {
-    transfer.transferWeekday = data.transfer_day.toString()
+    transfer.transferDay = data.transfer_day.toString()
   }
 
   return transfer

--- a/packages/cockpit/src/recipient/detail/format/index.js
+++ b/packages/cockpit/src/recipient/detail/format/index.js
@@ -46,12 +46,14 @@ function formatAntecipationAndTransferConfiguration (data) {
       cpfPhone: phone,
       cpfUrl: register.site_url,
       documentType: 'cpf',
+      cnpj: '',
     }
   } else {
     identification = {
       ...identification,
       cpf: data.bank_account.document_number,
       cpfInformation: false,
+      cnpj: '',
     }
   }
 
@@ -70,12 +72,14 @@ function formatAntecipationAndTransferConfiguration (data) {
       documentType: 'cnpj',
       partnerNumber: partners.length.toString(),
       ...partnersData,
+      cpf: '',
     }
   } else {
     identification = {
       ...identification,
       cnpj: data.bank_account.document_number,
       cnpjInformation: false,
+      cpf: '',
     }
   }
 

--- a/packages/cockpit/src/recipient/detail/format/index.js
+++ b/packages/cockpit/src/recipient/detail/format/index.js
@@ -36,50 +36,51 @@ function formatAntecipationAndTransferConfiguration (data) {
   const register = data.register_information
   const phone = pathOr('', ['phone_numbers', 0, 'number'], register)
 
-  if (data.bank_account.document_type === 'cpf' && register) {
-    identification = {
-      ...identification,
-      cpf: data.bank_account.document_number,
-      cpfEmail: register.email,
-      cpfInformation: true,
-      cpfName: register.name,
-      cpfPhone: phone,
-      cpfUrl: register.site_url,
-      documentType: 'cpf',
-      cnpj: '',
+  if (data.bank_account.document_type === 'cpf') {
+    if (register) {
+      identification = {
+        ...identification,
+        cpf: data.bank_account.document_number,
+        cpfEmail: register.email,
+        cpfInformation: true,
+        cpfName: register.name,
+        cpfPhone: phone,
+        cpfUrl: register.site_url,
+        documentType: 'cpf',
+        cnpj: '',
+      }
+    } else {
+      identification = {
+        ...identification,
+        cpf: data.bank_account.document_number,
+        cpfInformation: false,
+        cnpj: '',
+      }
     }
-  } else {
-    identification = {
-      ...identification,
-      cpf: data.bank_account.document_number,
-      cpfInformation: false,
-      cnpj: '',
-    }
-  }
-
-  if (data.bank_account.document_type === 'cnpj' && register) {
-    const partners = data.register_information.managing_partners || []
-    const partnersData = getPartnersData(partners)
-
-    identification = {
-      ...identification,
-      cnpj: data.bank_account.document_number,
-      cnpjEmail: register.email,
-      cnpjInformation: true,
-      cnpjName: register.company_name,
-      cnpjPhone: phone,
-      cnpjUrl: register.site_url,
-      documentType: 'cnpj',
-      partnerNumber: partners.length.toString(),
-      ...partnersData,
-      cpf: '',
-    }
-  } else {
-    identification = {
-      ...identification,
-      cnpj: data.bank_account.document_number,
-      cnpjInformation: false,
-      cpf: '',
+  } else if (data.bank_account.document_type === 'cnpj') {
+    if (register) {
+      const partners = data.register_information.managing_partners || []
+      const partnersData = getPartnersData(partners)
+      identification = {
+        ...identification,
+        cnpj: data.bank_account.document_number,
+        cnpjEmail: register.email,
+        cnpjInformation: true,
+        cnpjName: register.company_name,
+        cnpjPhone: phone,
+        cnpjUrl: register.site_url,
+        documentType: 'cnpj',
+        partnerNumber: partners.length.toString(),
+        ...partnersData,
+        cpf: '',
+      }
+    } else {
+      identification = {
+        ...identification,
+        cnpj: data.bank_account.document_number,
+        cnpjInformation: false,
+        cpf: '',
+      }
     }
   }
 

--- a/packages/cockpit/src/recipient/detail/format/mocks.js
+++ b/packages/cockpit/src/recipient/detail/format/mocks.js
@@ -175,7 +175,6 @@ const recipientTransferDataUpdated = {
   transferDay: '5',
   transferEnabled: true,
   transferInterval: 'monthly',
-  transferWeekday: '',
 }
 
 const recipientBankAccountDataUpdated = {

--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -517,7 +517,7 @@
       "field_number": "Este campo precisa ser um número",
       "field_repeated_document": "Não é permitido utilizar um número de documento mais de uma vez",
       "field_required": "Este campo é obrigatório",
-      "field_url": "É necessário fornecer um endereço 'http' ou 'https'",
+      "field_url": "É necessário fornecer um endereço válido",
       "fill_company_info": "Preencha abaixo as informações sobre a empresa do seu recebedor",
       "fill_partner_info": "Preencha abaixo as informações sobre os sócios do seu recebedor",
       "fill_recipient_info": "Preencha abaixo as informações sobre o seu recebedor",

--- a/packages/pilot/src/containers/AddRecipient/ConfigurationStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/ConfigurationStep/index.js
@@ -34,10 +34,10 @@ class ConfigurationsStep extends Component {
         anticipationDays: '15',
         anticipationModel: 'manual',
         anticipationVolumePercentage: '100',
-        transferDay: '5',
+        openedModal: false,
+        transferDay: '1',
         transferEnabled: false,
         transferInterval: 'daily',
-        transferWeekday: 'monday',
         ...props.data,
       },
       openedModal: false,
@@ -135,7 +135,6 @@ class ConfigurationsStep extends Component {
             transferDay: [required, isNumber],
             transferEnabled: [required],
             transferInterval: [required],
-            transferWeekday: [required],
           }}
         >
           <CardContent>
@@ -218,7 +217,6 @@ ConfigurationsStep.propTypes = {
     transferDay: PropTypes.string,
     transferEnabled: PropTypes.bool,
     transferInterval: PropTypes.string,
-    transferWeekday: PropTypes.string,
   }),
   errors: PropTypes.shape({
     anticipationDays: PropTypes.string,
@@ -227,7 +225,6 @@ ConfigurationsStep.propTypes = {
     transferDay: PropTypes.string,
     transferEnabled: PropTypes.string,
     transferInterval: PropTypes.string,
-    transferWeekday: PropTypes.string,
   }),
   maximumAnticipationDays: PropTypes.number,
   minimumAnticipationDelay: PropTypes.number,

--- a/packages/pilot/src/containers/AddRecipient/ConfirmStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/ConfirmStep/index.js
@@ -196,7 +196,6 @@ const renderTransferInterval = (configuration, t) => {
     transferDay,
     transferEnabled,
     transferInterval,
-    transferWeekday,
   } = configuration
 
   const transferTypes = {
@@ -224,7 +223,7 @@ const renderTransferInterval = (configuration, t) => {
             <span className={styles.info}>
               {
                 (transferInterval === 'weekly')
-                  ? t(`pages.add_recipient.${transferWeekday}`)
+                  ? t(`pages.add_recipient.${transferDay}`)
                   : transferDay
               }
             </span>
@@ -353,7 +352,6 @@ ConfirmStep.propTypes = {
       transferDay: PropTypes.string,
       transferEnabled: PropTypes.bool,
       transferInterval: PropTypes.string,
-      transferWeekday: PropTypes.string,
     }).isRequired,
     [IDENTIFICATION]: PropTypes.shape({
       cnpj: PropTypes.string,
@@ -394,7 +392,6 @@ ConfirmStep.defaultProps = {
       transferDay: '',
       transferEnabled: false,
       transferInterval: '',
-      transferWeekday: '',
     },
     [IDENTIFICATION]: {
       cnpj: '',

--- a/packages/pilot/src/containers/AddRecipient/IdentificationStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/IdentificationStep/index.js
@@ -54,10 +54,6 @@ const getValidations = (data, t) => {
     validateCpfCnpjMessage = t('pages.add_recipient.field_invalid_cnpj')
   }
 
-  if (data.documentType === 'cnpj' && data.cnpjInformation === true) {
-    validateCpfCnpjMessage = t('pages.add_recipient.field_invalid_cpf')
-  }
-
   const validateEmailMessage =
     t('pages.add_recipient.field_invalid_email')
 

--- a/packages/pilot/src/containers/AddRecipient/IdentificationStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/IdentificationStep/index.js
@@ -569,7 +569,6 @@ IdentificationStep.propTypes = {
     transferDay: PropTypes.string,
     transferEnabled: PropTypes.string,
     transferInterval: PropTypes.string,
-    transferWeekday: PropTypes.string,
   }),
   onCancel: PropTypes.func.isRequired,
   onContinue: PropTypes.func.isRequired,

--- a/packages/pilot/src/containers/AddRecipient/IdentificationStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/IdentificationStep/index.js
@@ -44,6 +44,7 @@ const partnerInitialization = {
 }
 
 const getValidations = (data, t) => {
+  console.log(data)
   const requiredMessage =
     t('pages.add_recipient.field_required')
 
@@ -113,7 +114,6 @@ const getValidations = (data, t) => {
       partner4: partnerValidations,
     }
   }
-
   return {
     cpf: [required, validateCpfCnpj],
     cpfEmail: [required, validateEmailIfExists],

--- a/packages/pilot/src/containers/AddRecipient/IdentificationStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/IdentificationStep/index.js
@@ -44,7 +44,6 @@ const partnerInitialization = {
 }
 
 const getValidations = (data, t) => {
-  console.log(data)
   const requiredMessage =
     t('pages.add_recipient.field_required')
 

--- a/packages/pilot/src/containers/Filter/index.js
+++ b/packages/pilot/src/containers/Filter/index.js
@@ -11,7 +11,6 @@ import {
   Row,
   Col,
   CheckboxGroup,
-  Spacing,
 } from 'former-kit'
 
 import Form from 'react-vanilla-form'
@@ -168,7 +167,6 @@ class Filters extends Component {
             {t('components.filter.more')}
           </Button>
         }
-        <Spacing size="flex" />
         <Button
           relevance={
             hasChanged

--- a/packages/pilot/src/containers/Filter/index.js
+++ b/packages/pilot/src/containers/Filter/index.js
@@ -94,15 +94,35 @@ class Filters extends Component {
   }
 
   componentDidUpdate (prevProps, prevState) {
-    const prevQuery = stringifyDates(prevState.query)
-    const currQuery = stringifyDates(this.props.query)
+    const prevStateQuery = stringifyDates(prevState.query)
+    const currStateQuery = stringifyDates(this.state.query)
+    const prevPropQuery = stringifyDates(prevProps.query)
+    const currPropQuery = stringifyDates(this.props.query)
 
-    if (!equals(prevQuery, currQuery)) {
-      this.setState({ // eslint-disable-line react/no-did-update-set-state
+    const propQueryVerify = (
+      !equals(prevPropQuery, currPropQuery)
+      && !isEmpty(currPropQuery)
+    )
+
+    const stateQueryVerify = (
+      !equals(prevStateQuery, currStateQuery)
+      && !isEmpty(currStateQuery)
+    )
+
+    if (propQueryVerify) {
+      return this.setState({ // eslint-disable-line react/no-did-update-set-state
         hasChanged: true,
         query: this.props.query,
       })
     }
+
+    if (stateQueryVerify) {
+      return this.setState({ // eslint-disable-line react/no-did-update-set-state
+        hasChanged: true,
+      })
+    }
+
+    return undefined
   }
 
   handleToogeMoreFilters () {

--- a/packages/pilot/src/containers/RecipientDetails/Balance/style.css
+++ b/packages/pilot/src/containers/RecipientDetails/Balance/style.css
@@ -1,5 +1,9 @@
 @import "former-kit-skin-pagarme/dist/styles/spacing.css";
 
+.filter {
+  display: flex;
+}
+
 .filter > button {
   margin-left: var(--spacing-small);
 }

--- a/packages/pilot/src/containers/RecipientDetails/Config/TransferContent/index.js
+++ b/packages/pilot/src/containers/RecipientDetails/Config/TransferContent/index.js
@@ -34,7 +34,6 @@ const TransferContent = ({
         transferDay: [required, number],
         transferEnabled: [required],
         transferInterval: [required],
-        transferWeekday: [required],
       }}
       onChange={onChange}
       onSubmit={onSave}
@@ -77,7 +76,6 @@ TransferContent.propTypes = {
     transferDay: PropTypes.string,
     transferEnabled: PropTypes.bool,
     transferInterval: PropTypes.string,
-    transferWeekday: PropTypes.string,
   }),
   onCancel: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/packages/pilot/src/containers/RecipientDetails/Config/index.js
+++ b/packages/pilot/src/containers/RecipientDetails/Config/index.js
@@ -318,7 +318,6 @@ RecipientDetailConfig.propTypes = {
     transferDay: PropTypes.string,
     transferEnabled: PropTypes.bool,
     transferInterval: PropTypes.string,
-    transferWeekday: PropTypes.string,
   }),
 }
 
@@ -334,7 +333,6 @@ RecipientDetailConfig.defaultProps = {
     transferDay: '',
     transferEnabled: true,
     transferInterval: '',
-    transferWeekday: '',
   },
 }
 

--- a/packages/pilot/src/containers/RecipientTable/index.js
+++ b/packages/pilot/src/containers/RecipientTable/index.js
@@ -38,7 +38,6 @@ const RecipientTable = ({
   onSelectRow,
   pagination,
   push,
-  query,
   rows,
   selectedRows,
   t,
@@ -60,10 +59,9 @@ const RecipientTable = ({
         >
           <Filter
             disabled={loading}
-            onChange={onFilterChange}
+            onConfirm={onFilterChange}
             onClear={onFilterClear}
             options={filterOptions}
-            query={query}
             t={t}
           >
             <Input
@@ -180,9 +178,6 @@ RecipientTable.propTypes = {
     total: PropTypes.number,
   }).isRequired,
   push: PropTypes.func.isRequired,
-  query: PropTypes.shape({
-    search: PropTypes.string,
-  }),
   rows: PropTypes.arrayOf(PropTypes.shape({
     anticipatable_volume_percentage: PropTypes.number,
     automatic_anticipation_days: PropTypes.string,
@@ -203,12 +198,6 @@ RecipientTable.propTypes = {
   })).isRequired,
   selectedRows: PropTypes.arrayOf(PropTypes.number).isRequired,
   t: PropTypes.func.isRequired,
-}
-
-RecipientTable.defaultProps = {
-  query: {
-    search: '',
-  },
 }
 
 export default RecipientTable

--- a/packages/pilot/src/containers/RecipientTable/tableColumns.js
+++ b/packages/pilot/src/containers/RecipientTable/tableColumns.js
@@ -149,7 +149,8 @@ const getDefaultColumns = ({
           tv={6}
         >
           <Row>
-            {columnData([
+            {data.transfer_day !== 0 && data.transfer_interval === 'weekly' &&
+              columnData([
               {
                 content: t(`pages.recipients.transfer_enabled_boolean.${data.transfer_enabled}`),
                 title: t('pages.recipients.transfer_enabled'),
@@ -158,11 +159,19 @@ const getDefaultColumns = ({
                 content: t(`pages.recipients.transfer_interval_of.${data.transfer_interval}`),
                 title: t('pages.recipients.transfer_interval'),
               },
-              {
-                content: data.transfer_day,
-                title: t('pages.recipients.transfer_day'),
-              },
+              renderColumnTransferDay(data, t),
             ])}
+            {data.transfer_day === 0 &&
+              columnData([
+              {
+                content: t(`pages.recipients.transfer_enabled_boolean.${data.transfer_enabled}`),
+                title: t('pages.recipients.transfer_enabled'),
+              }, {
+                content: t(`pages.recipients.transfer_interval_of.${data.transfer_interval}`),
+                title: t('pages.recipients.transfer_interval'),
+              },
+            ])
+            }
           </Row>
         </Col>
       </Grid>

--- a/packages/pilot/src/containers/RecipientTable/tableColumns.js
+++ b/packages/pilot/src/containers/RecipientTable/tableColumns.js
@@ -51,6 +51,23 @@ const antecipationModel = (data) => {
   return 'custom'
 }
 
+const renderColumnTransferDay = (data, t) => {
+  const weekDaysMap = {
+    1: t('pages.add_recipient.monday'),
+    2: t('pages.add_recipient.tuesday'),
+    3: t('pages.add_recipient.wednesday'),
+    4: t('pages.add_recipient.thursday'),
+    5: t('pages.add_recipient.friday'),
+  }
+
+  return (
+    {
+      content: weekDaysMap[data.transfer_day],
+      title: t('pages.recipients.transfer_day'),
+    }
+  )
+}
+
 const getDefaultColumns = ({
   onDetailsClick,
   t,

--- a/packages/pilot/src/pages/Recipients/Add/Add.js
+++ b/packages/pilot/src/pages/Recipients/Add/Add.js
@@ -72,7 +72,7 @@ class AddRecipientPage extends Component {
   }
 
   onViewDetails (recipientId) {
-    this.props.history.replace(`/recipients/details/${recipientId}`)
+    this.props.history.replace(`/recipients/detail/${recipientId}`)
   }
 
   submitRecipient (recipient) {

--- a/packages/pilot/src/pages/Recipients/Search/Search.js
+++ b/packages/pilot/src/pages/Recipients/Search/Search.js
@@ -90,7 +90,11 @@ const isRecipientId = (recipientText) => {
 }
 
 const isBankAccount = (bankAccount) => {
+  if (bankAccount.length > 10) {
+    return false
+  }
   const bankNumber = Number.parseInt(bankAccount, 10)
+
   return Number.isInteger(bankNumber)
 }
 

--- a/packages/pilot/src/validation/protocol.js
+++ b/packages/pilot/src/validation/protocol.js
@@ -1,2 +1,3 @@
-const webSite = /https?:\/\/.+/
-export default message => value => !webSite.test(value) && message
+import isUrl from 'validator/lib/isURL'
+
+export default message => value => (!value || !isUrl(value)) && message

--- a/packages/pilot/stories/containers/AddRecipient/ConfigurationsStep/index.js
+++ b/packages/pilot/stories/containers/AddRecipient/ConfigurationsStep/index.js
@@ -9,10 +9,9 @@ const defaultData = {
   anticipationDays: '25',
   anticipationModel: 'automatic_volume',
   anticipationVolumePercentage: '85',
-  transferDay: '5',
+  transferDay: '1',
   transferEnabled: true,
   transferInterval: 'weekly',
-  transferWeekday: 'wednesday',
 }
 
 const ConfigurationStep = () => (

--- a/packages/pilot/stories/containers/AddRecipient/ConfirmStep/index.js
+++ b/packages/pilot/stories/containers/AddRecipient/ConfirmStep/index.js
@@ -19,10 +19,9 @@ const mockData = {
     anticipationDays: '25',
     anticipationModel: 'automatic_volume',
     anticipationVolumePercentage: '50',
-    transferDay: '15',
+    transferDay: '1',
     transferEnabled: true,
     transferInterval: 'monthly',
-    transferWeekday: 'tuesday',
   },
   identification: {
     cnpj: '11.111.111/1111-11',

--- a/packages/pilot/stories/containers/RecipientDetails/Config/index.js
+++ b/packages/pilot/stories/containers/RecipientDetails/Config/index.js
@@ -33,10 +33,9 @@ const mockAnticipation = {
 }
 
 const mockTransfer = {
-  transferDay: '5',
+  transferDay: '1',
   transferEnabled: true,
   transferInterval: 'weekly',
-  transferWeekday: 'wednesday',
 }
 
 const mockBankAccount = {

--- a/packages/pilot/stories/containers/RecipientDetails/index.js
+++ b/packages/pilot/stories/containers/RecipientDetails/index.js
@@ -28,10 +28,9 @@ const mockInformation = {
     anticipationDays: '',
     anticipationModel: 'Automática por volume',
     anticipationVolumePercentage: '50',
-    transferDay: '15',
+    transferDay: '1',
     transferEnabled: true,
     transferInterval: 'Mensal',
-    transferWeekday: 'Terça-feira',
   },
   identification: {
     cnpj: '11.111.111/1111-11',
@@ -109,10 +108,9 @@ const mockConfiguration = {
   onCancel: action('Cancel'),
   onSave: action('Saved'),
   transfer: {
-    transferDay: '5',
+    transferDay: '1',
     transferEnabled: true,
     transferInterval: 'weekly',
-    transferWeekday: 'wednesday',
   },
 }
 


### PR DESCRIPTION
## Contexto
Este PR visa corrigir alguns erros encontrados e por nós (time caesar) ao longo do próprio desenvolvimento e outros identificados em alguns PR's por contribuintes de outros times.

## Checklist
- [x] Ao finalizar o cadastro selecionando a transferência como semanal, o valor é apresentado sempre como "Segunda-feira" na tela de confirmação, independente de qual opção for selecionada.
- [x]  Mostrar a lista de contas bancárias apenas as contas com mesmo `document_number`
- [x]  Double check das validações de campos do formulário contra as regras de valores que a API aceita.
- [x]  Quando o recebedor foi cadastrado por CPF, o estado de identificação preenche erroneamente a chave `cnpj` com o número do CPF. - Mais Informações.
- [x]  Ajustar a mensagem de CNPJ inválido (está exibindo a mesma mensagem do CPF);
- [x]  No expansível da tabela, para transferências diárias habilitadas, estamos exibindo o valor 0.
- [x] O campo de pesquisa na listagem de recebedores não faz mais uso de toda a largura da página. fazer com que fique com o tamanho original ou mover os botões de ação para a esquerda.
- [x] Ao tentar filtrar por um CPF a listagem de recebedores trava, e eventualmente a sessão cai após isso. Logando novamente o texto pesquisado permanece.
- [x] Na mensagem de sucesso na criação de um recebedor, ao clicar em ver recebedor estamos direcionando o usuário para a listagem e não para o detalhe desse recebedor.
- [x] Corrigir o filtro de Recebedores.
- [x] Verificar se o Date Input está funcionando corretamente.
- [x] Alinhar o botão de _Filtrar_ do Date Input.

## Issues linkadas
https://github.com/pagarme/caesar/issues/330

## Notas de deploy
- Fazer um `git clone` no repositório
- Aplicar um `yarn` para instalar as dependências
- `yarn start` para rodar a aplicação

## Como testar?
A ordem dos commit's segue a ordem da checklist citada acima.