### PR TITLE
Adiciona Virtual Page Views nos passos de cadastro de recebedor

### DIFF
--- a/packages/pilot/src/containers/AddRecipient/BankAccountStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/BankAccountStep/index.js
@@ -16,6 +16,7 @@ import AddAccount, {
 } from './AddAccount'
 
 import SelectAccount, { userAccountProps } from './SelectAccount'
+import { virtualPageView } from '../../../vendor/googleTagManager'
 import style from './style.css'
 
 const hasItems = complement(either(isEmpty, isNil))
@@ -40,6 +41,13 @@ class BankAccountStep extends Component {
 
     this.state = { selectedForm }
     this.handleFormSelectionChange = this.handleFormSelectionChange.bind(this)
+  }
+
+  componentDidMount () {
+    virtualPageView({
+      path: '/virtual/recipient/add/bank_account',
+      title: 'Add Recipient - Bank Account',
+    })
   }
 
   handleFormSelectionChange (selectedForm) {

--- a/packages/pilot/src/containers/AddRecipient/ConclusionStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/ConclusionStep/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 import {
@@ -9,33 +9,46 @@ import {
 
 import SuccessIcon from './SuccessIcon.svg'
 import style from '../style.css'
+import { virtualPageView } from '../../../vendor/googleTagManager'
 
-const ConclusionStep = ({
-  onExit,
-  onViewDetails,
-  t,
-}) => (
-  <CardContent className={style.flex}>
-    <SuccessIcon />
-    <h2 className={style.title}>
-      {t('pages.add_recipient.everything_ok')}
-    </h2>
-    <p className={style.centerText}>
-      {t('pages.add_recipient.recipient_created_success')}
-      <br />
-      {t('pages.add_recipient.can_see_recipient')}
-    </p>
-    <div>
-      <Button fill="outline" onClick={onExit}>
-        {t('pages.add_recipient.exit')}
-      </Button>
-      <Spacing size="large" />
-      <Button fill="gradient" onClick={onViewDetails}>
-        {t('pages.add_recipient.see_recipient')}
-      </Button>
-    </div>
-  </CardContent>
-)
+class ConclusionStep extends Component {
+  componentDidMount () {
+    virtualPageView({
+      path: '/virtual/recipient/add/conclusion',
+      title: 'Add Recipient - Conclusion',
+    })
+  }
+
+  render () {
+    const {
+      onExit,
+      onViewDetails,
+      t,
+    } = this.props
+    return (
+      <CardContent className={style.flex}>
+        <SuccessIcon />
+        <h2 className={style.title}>
+          {t('pages.add_recipient.everything_ok')}
+        </h2>
+        <p className={style.centerText}>
+          {t('pages.add_recipient.recipient_created_success')}
+          <br />
+          {t('pages.add_recipient.can_see_recipient')}
+        </p>
+        <div>
+          <Button fill="outline" onClick={onExit}>
+            {t('pages.add_recipient.exit')}
+          </Button>
+          <Spacing size="large" />
+          <Button fill="gradient" onClick={onViewDetails}>
+            {t('pages.add_recipient.see_recipient')}
+          </Button>
+        </div>
+      </CardContent>
+    )
+  }
+}
 
 ConclusionStep.propTypes = {
   onExit: PropTypes.func.isRequired,

--- a/packages/pilot/src/containers/AddRecipient/ConfigurationStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/ConfigurationStep/index.js
@@ -21,6 +21,7 @@ import createBetweenValidation from '../../../validation/between'
 import createLessThanValidation from '../../../validation/lessThan'
 
 import HelpModal from '../../RecipientDetails/Config/HelpModal'
+import { virtualPageView } from '../../../vendor/googleTagManager'
 
 import style from './style.css'
 
@@ -47,6 +48,13 @@ class ConfigurationsStep extends Component {
     this.transferHandler = this.transferHandler.bind(this)
     this.handleOpenHelpModal = this.handleOpenHelpModal.bind(this)
     this.handleCloseHelpModal = this.handleCloseHelpModal.bind(this)
+  }
+
+  componentDidMount () {
+    virtualPageView({
+      path: '/virtual/recipient/add/configuration',
+      title: 'Add Recipient - Configuration',
+    })
   }
 
   onFormSubmit (formData, formErrors) {

--- a/packages/pilot/src/containers/AddRecipient/ConfirmStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/ConfirmStep/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 
 import {
@@ -17,6 +17,7 @@ import PartnerInfo from './PartnerInfo'
 import styles from './style.css'
 
 import { accountProps, accountDefaultProps } from '../BankAccountStep'
+import { virtualPageView } from '../../../vendor/googleTagManager'
 
 import {
   BANK_ACCOUNT,
@@ -261,57 +262,70 @@ const renderTransferConfig = (configuration, action, t) => {
   )
 }
 
-const ConfirmStep = ({
-  data,
-  onBack,
-  onEdit,
-  onCancel,
-  onContinue,
-  t,
-}) => (
-  <Fragment>
-    <CardContent className={styles.paddingBottom}>
-      <h3 className={styles.title}>{t('pages.add_recipient.confirm_recipient_registration')}</h3>
-      <h4 className={styles.subtitle}>
-        {t('pages.add_recipient.confirm_and_finish')}
-      </h4>
-      <Grid className={styles.paddingBottom}>
-        <hr className={styles.line} />
-        {renderReceiverInfo(data[IDENTIFICATION], onEdit, t)}
-        {renderPartnerInfo(data[IDENTIFICATION], onEdit, t)}
-        {renderBankAccount(data[BANK_ACCOUNT], onEdit, t)}
-        {renderAnticipationConfig(data[CONFIGURATION], onEdit, t)}
-        {renderTransferConfig(data[CONFIGURATION], onEdit, t)}
-      </Grid>
-    </CardContent>
-    <CardActions>
-      <Button
-        type="button"
-        relevance="low"
-        onClick={onCancel}
-        fill="outline"
-      >
-        {t('pages.add_recipient.cancel')}
-      </Button>
-      <Spacing />
-      <Button
-        type="button"
-        onClick={onBack}
-        fill="outline"
-      >
-        {t('pages.add_recipient.back')}
-      </Button>
-      <Spacing size="medium" />
-      <Button
-        type="submit"
-        fill="gradient"
-        onClick={() => onContinue()}
-      >
-        {t('pages.add_recipient.create_recipient')}
-      </Button>
-    </CardActions>
-  </Fragment>
-)
+class ConfirmStep extends Component {
+  componentDidMount () {
+    virtualPageView({
+      path: '/virtual/recipient/add/confirm',
+      title: 'Add Recipient - Confirm',
+    })
+  }
+
+  render () {
+    const {
+      data,
+      onBack,
+      onEdit,
+      onCancel,
+      onContinue,
+      t,
+    } = this.props
+
+    return (
+      <Fragment>
+        <CardContent className={styles.paddingBottom}>
+          <h3 className={styles.title}>{t('pages.add_recipient.confirm_recipient_registration')}</h3>
+          <h4 className={styles.subtitle}>
+            {t('pages.add_recipient.confirm_and_finish')}
+          </h4>
+          <Grid className={styles.paddingBottom}>
+            <hr className={styles.line} />
+            {renderReceiverInfo(data[IDENTIFICATION], onEdit, t)}
+            {renderPartnerInfo(data[IDENTIFICATION], onEdit, t)}
+            {renderBankAccount(data[BANK_ACCOUNT], onEdit, t)}
+            {renderAnticipationConfig(data[CONFIGURATION], onEdit, t)}
+            {renderTransferConfig(data[CONFIGURATION], onEdit, t)}
+          </Grid>
+        </CardContent>
+        <CardActions>
+          <Button
+            type="button"
+            relevance="low"
+            onClick={onCancel}
+            fill="outline"
+          >
+            {t('pages.add_recipient.cancel')}
+          </Button>
+          <Spacing />
+          <Button
+            type="button"
+            onClick={onBack}
+            fill="outline"
+          >
+            {t('pages.add_recipient.back')}
+          </Button>
+          <Spacing size="medium" />
+          <Button
+            type="submit"
+            fill="gradient"
+            onClick={() => onContinue()}
+          >
+            {t('pages.add_recipient.create_recipient')}
+          </Button>
+        </CardActions>
+      </Fragment>
+    )
+  }
+}
 
 const partnerPropTypes = PropTypes.shape({
   cpf: PropTypes.string,

--- a/packages/pilot/src/containers/AddRecipient/ErrorStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/ErrorStep/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { CardContent } from 'former-kit'
 
@@ -12,19 +12,30 @@ import {
   UNKNOWN_ERROR,
 } from '../../../formatters/errorType'
 
-const ErrorStep = (props) => {
-  const { t } = props
+import { virtualPageView } from '../../../vendor/googleTagManager'
 
-  return (
-    <CardContent className={style.flex}>
-      <ErrorIcon />
-      <h2 className={style.title}>
-        {t('pages.add_recipient.ops')}
-      </h2>
-      <ErrorMessage {...props} />
-      <ErrorButtons {...props} />
-    </CardContent>
-  )
+class ErrorStep extends Component {
+  componentDidMount () {
+    virtualPageView({
+      path: '/virtual/recipient/add/error',
+      title: 'Add Recipient - Error',
+    })
+  }
+
+  render () {
+    const { t } = this.props
+
+    return (
+      <CardContent className={style.flex}>
+        <ErrorIcon />
+        <h2 className={style.title}>
+          {t('pages.add_recipient.ops')}
+        </h2>
+        <ErrorMessage {...this.props} />
+        <ErrorButtons {...this.props} />
+      </CardContent>
+    )
+  }
 }
 
 ErrorStep.propTypes = {

--- a/packages/pilot/src/containers/AddRecipient/IdentificationStep/index.js
+++ b/packages/pilot/src/containers/AddRecipient/IdentificationStep/index.js
@@ -18,6 +18,7 @@ import {
 
 import { range } from 'ramda'
 
+import { virtualPageView } from '../../../vendor/googleTagManager'
 import createCpfCnpjValidation from '../../../validation/cpfCnpj'
 import createEmailValidation from '../../../validation/email'
 import createPhoneValidation from '../../../validation/phone'
@@ -159,6 +160,13 @@ class IdentificationStep extends Component {
     this.toggleAdditionalInformation =
       this.toggleAdditionalInformation.bind(this)
     this.validateRepeatedDocuments = this.validateRepeatedDocuments.bind(this)
+  }
+
+  componentDidMount () {
+    virtualPageView({
+      path: '/virtual/recipient/add/identification',
+      title: 'Add Recipient - Identification',
+    })
   }
 
   onFormSubmit (formData, formErrors) {

--- a/packages/pilot/src/vendor/googleTagManager.js
+++ b/packages/pilot/src/vendor/googleTagManager.js
@@ -66,11 +66,20 @@ export const inactiveCompanyLogin = () => {
 /**
  * Trigger activeCompanyLogin event
  */
-
 export const activeCompanyLogin = () => {
   if (hasProperty(window.dataLayer)) {
     window.dataLayer.push({
       event: 'activeCompanyLogin',
+    })
+  }
+}
+
+export const virtualPageView = ({ path, title }) => {
+  if (hasProperty(window.dataLayer)) {
+    window.dataLayer.push({
+      event: 'virtualPageView',
+      pagePath: path,
+      pageTitle: title,
     })
   }
 }


### PR DESCRIPTION
## Contexto

Este PR faz com que um evento customizado seja emitido para o Google Tag Manager a cada passo do formulário de adicionar recebedores, fazendo com que o Google Analytics considere cada passo como uma visualização de página.

Isto permitirá que seja feito tracking do formulário, criando um funil de conversão.

## Issues linkadas
- [x] Resolves https://github.com/pagarme/caesar/issues/313

## Como testar?

Utilize o modo de visualização do Google Tag Manager para ver os eventos sendo disparados, e verifique se o evento `virtualPageView` é disparado a cada passo do fluxo de cadastro de recebedor.

Também cheque o relatório de páginas sendo acessadas em tempo real do Google Analytics e verifique se existem page views com URLs do tipo `/virtual/recipient/add/`.
