### PR TITLE
transactions-list: refactor table columns and filter

### DIFF
--- a/packages/cockpit/src/transactions/search/query.js
+++ b/packages/cockpit/src/transactions/search/query.js
@@ -14,6 +14,7 @@ import {
   contains,
   dec,
   defaultTo,
+  either,
   equals,
   flatten,
   has,
@@ -35,12 +36,14 @@ import {
   props,
   reduce,
   reject,
+  replace,
   toPairs,
   when,
 } from 'ramda'
 
 const termsKeys = [
   'id',
+  'customer.documents.number',
   'customer.document_number',
   'customer.email',
   'customer.name',
@@ -150,6 +153,8 @@ const parseFilters = pipe(
   flatten
 )
 
+const compareDocuments = either(equals('customer.documents.number'), equals('customer.document_number'))
+
 const parseSearch = keys => (search) => {
   if (!search) {
     return []
@@ -171,6 +176,17 @@ const parseSearch = keys => (search) => {
       }
 
       return acc
+    }
+
+    if (compareDocuments(key)) {
+      return [
+        ...acc,
+        {
+          term: {
+            [key]: replace(/\.|-|\//gi, '', search),
+          },
+        },
+      ]
     }
 
     return [

--- a/packages/cockpit/src/transactions/search/query.test.js
+++ b/packages/cockpit/src/transactions/search/query.test.js
@@ -92,6 +92,11 @@ const expectedQuery = {
               },
               {
                 term: {
+                  'customer.documents.number': '12345',
+                },
+              },
+              {
+                term: {
                   'customer.document_number': '12345',
                 },
               },
@@ -156,6 +161,11 @@ describe('Transactions from filter', () => {
             {
               term: {
                 id: 12345,
+              },
+            },
+            {
+              term: {
+                'customer.documents.number': '12345',
               },
             },
             {
@@ -552,6 +562,11 @@ describe('Transactions from filter', () => {
       [
         {
           or: [
+            {
+              term: {
+                'customer.documents.number': 'aaaa',
+              },
+            },
             {
               term: {
                 'customer.document_number': 'aaaa',

--- a/packages/pilot/src/containers/TransactionsList/tableColumns.js
+++ b/packages/pilot/src/containers/TransactionsList/tableColumns.js
@@ -1,5 +1,12 @@
 import React from 'react'
 import {
+  always,
+  applySpec,
+  either,
+  head,
+  ifElse,
+  isEmpty,
+  isNil,
   path,
   pick,
   pipe,
@@ -19,6 +26,28 @@ import renderStatusLegend from '../../containers/TransactionsList/renderStatusLe
 const convertPaymentValue = property => pipe(
   path(['payment', property]),
   formatCurrency
+)
+
+const formatDocument = applySpec({
+  number: pipe(
+    prop('number'),
+    formatCpfCnpj
+  ),
+  type: prop('type'),
+})
+
+const getDefaultDocumentNumber = pipe(
+  prop('documents'),
+  ifElse(
+    either(isNil, isEmpty),
+    always(null),
+    pipe(
+      head,
+      formatDocument,
+      prop('number'),
+      formatCpfCnpj
+    )
+  )
 )
 
 const getDefaultColumns = ({ onDetailsClick, t }) => ([
@@ -42,8 +71,8 @@ const getDefaultColumns = ({ onDetailsClick, t }) => ([
   {
     accessor: ['customer', 'document_number'],
     renderer: pipe(
-      path(['customer', 'document_number']),
-      formatCpfCnpj
+      prop('customer'),
+      getDefaultDocumentNumber
     ),
     title: t('models.transaction.document'),
   },


### PR DESCRIPTION
## Contexto
Na versão 2017-08-28 da API, os números de documento passaram a ser registrados em um array em customer, gerando uma quebra de interface com as versões anteriores. Além de não filtrar no campo de busca por CPF. Esse PR conserta esses erros.

Foi utilizado o mesmo tratamento da página de detalhes da transação, que apresenta o número de documento corretamente para qualquer versão da API.

## Checklist
- [ ] Número de documento ser exibido na lista de transações
- [ ] Filtragem por número de documento ocorrer normalmente em qualquer versão da API

## Issues linkadas
- [ ] Resolves https://github.com/pagarme/pilot/issues/1073

## Screenshots
<img width="565" alt="Screen Shot 2019-03-19 at 15 47 34" src="https://user-images.githubusercontent.com/20358128/54633146-5847ea00-4a5e-11e9-80ca-25c162118775.png">

## Como testar?
- Vá para branch `refactor/transaction-search-cpf`
- Rode `yarn build` no `packages/cockpit`
- Rode `yarn start` para abrir a pilot
- Confira na página `Transações` se o CPF do customer aparece em cada transação realizada. 
- Confira se alguma transação pode ser filtrada por CPF ou CNPJ, com pontos ou sem pontos. Se sim, é isso aê! :tada:
