### PR TITLE
Sidebar: update Sidebar

### DIFF
--- a/packages/pilot/src/containers/Sidebar/index.js
+++ b/packages/pilot/src/containers/Sidebar/index.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { propOr, __ } from 'ramda'
+// import { propOr, __ } from 'ramda'
 
 import {
   Button,
-  Flexbox,
-  Popover,
-  PopoverContent,
+  // Flexbox,
+  // Popover,
+  // PopoverContent,
   Sidebar,
   SidebarHeader,
   SidebarLink,
@@ -14,21 +14,21 @@ import {
 } from 'former-kit'
 
 import IconMenu from 'emblematic-icons/svg/Menu32.svg'
-import IconWallet from 'emblematic-icons/svg/Wallet32.svg'
+// import IconWallet from 'emblematic-icons/svg/Wallet32.svg'
 
-import style from './style.css'
+// import style from './style.css'
 
-import SidebarSections from '../../components/SidebarSections'
-import SidebarSummary from '../../components/SidebarSummary'
-import formatDecimalCurrency from '../../formatters/decimalCurrency'
-import environment from '../../environment'
+// import SidebarSections from '../../components/SidebarSections'
+// import SidebarSummary from '../../components/SidebarSummary'
+// import formatDecimalCurrency from '../../formatters/decimalCurrency'
+// import environment from '../../environment'
 
 class SidebarContainer extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
       collapsed: false,
-      summaryCollapsed: true,
+      // summaryCollapsed: true,
     }
 
     this.handleToggleSidebar = this.handleToggleSidebar.bind(this)
@@ -39,49 +39,49 @@ class SidebarContainer extends React.Component {
     this.setState({ collapsed: !collapsed })
   }
 
-  renderSections () {
-    const {
-      balance,
-      onAnticipate,
-      onWithdraw,
-      t,
-    } = this.props
+  // renderSections () {
+  //   const {
+  //     balance,
+  //     onAnticipate,
+  //     onWithdraw,
+  //     t,
+  //   } = this.props
 
-    const getFrombalance = propOr(null, __, balance)
-    const available = getFrombalance('available')
-    const waitingFunds = getFrombalance('waitingFunds')
+  //   const getFrombalance = propOr(null, __, balance)
+  //   const available = getFrombalance('available')
+  //   const waitingFunds = getFrombalance('waitingFunds')
 
-    return (
-      <SidebarSections
-        sections={[
-          {
-            action: onWithdraw,
-            actionTitle: t('pages.sidebar.withdraw'),
-            title: t('pages.sidebar.available'),
-            value: <span><small>{t('pages.sidebar.currency_symbol')}</small> {formatDecimalCurrency(available)}</span>,
-          },
-          {
-            action: onAnticipate,
-            actionTitle: t('pages.sidebar.anticipation'),
-            title: t('pages.sidebar.waiting_funds'),
-            value: <span><small>{t('pages.sidebar.currency_symbol')}</small> {formatDecimalCurrency(waitingFunds)}</span>,
-          },
-        ]}
-      />
-    )
-  }
+  //   return (
+  //     <SidebarSections
+  //       sections={[
+  //         {
+  //           action: onWithdraw,
+  //           actionTitle: t('pages.sidebar.withdraw'),
+  //           title: t('pages.sidebar.available'),
+  //           value: <span><small>{t('pages.sidebar.currency_symbol')}</small> {formatDecimalCurrency(available)}</span>,
+  //         },
+  //         {
+  //           action: onAnticipate,
+  //           actionTitle: t('pages.sidebar.anticipation'),
+  //           title: t('pages.sidebar.waiting_funds'),
+  //           value: <span><small>{t('pages.sidebar.currency_symbol')}</small> {formatDecimalCurrency(waitingFunds)}</span>,
+  //         },
+  //       ]}
+  //     />
+  //   )
+  // }
 
   render () {
     const {
       collapsed,
-      summaryCollapsed,
+      // summaryCollapsed,
     } = this.state
     const {
-      companyName,
+      // companyName,
       links,
       logo: Logo,
       onLinkClick,
-      sessionId,
+      // sessionId,
       t,
     } = this.props
 
@@ -98,7 +98,7 @@ class SidebarContainer extends React.Component {
           />
         </SidebarHeader>
 
-        {!collapsed &&
+        {/* {!collapsed &&
           <SidebarSummary
             collapsed={summaryCollapsed}
             onClick={() => this.setState({
@@ -113,9 +113,9 @@ class SidebarContainer extends React.Component {
           >
             {this.renderSections()}
           </SidebarSummary>
-        }
+        } */}
 
-        {collapsed &&
+        {/* {collapsed &&
           <Popover
             base="dark"
             content={
@@ -134,7 +134,7 @@ class SidebarContainer extends React.Component {
               />
             </SidebarLinks>
           </Popover>
-        }
+        } */}
 
         <SidebarLinks>
           {links.map(({
@@ -154,7 +154,7 @@ class SidebarContainer extends React.Component {
             />
           ))}
         </SidebarLinks>
-        {!collapsed &&
+        {/* {!collapsed &&
           <Flexbox
             className={style.backToOldVersion}
             justifyContent="center"
@@ -170,18 +170,18 @@ class SidebarContainer extends React.Component {
               {t('pages.sidebar.back_to_old_version')}
             </Button>
           </Flexbox>
-        }
+        } */}
       </Sidebar>
     )
   }
 }
 
 SidebarContainer.propTypes = {
-  balance: PropTypes.shape({
-    available: PropTypes.number,
-    waitingFunds: PropTypes.number,
-  }).isRequired,
-  companyName: PropTypes.string,
+  // balance: PropTypes.shape({
+  //   available: PropTypes.number,
+  //   waitingFunds: PropTypes.number,
+  // }).isRequired,
+  // companyName: PropTypes.string,
   links: PropTypes.arrayOf(PropTypes.shape({
     active: PropTypes.bool,
     component: PropTypes.func,
@@ -190,18 +190,18 @@ SidebarContainer.propTypes = {
     title: PropTypes.string,
   })).isRequired,
   logo: PropTypes.func.isRequired,
-  onAnticipate: PropTypes.func,
+  // onAnticipate: PropTypes.func,
   onLinkClick: PropTypes.func.isRequired,
-  onWithdraw: PropTypes.func,
-  sessionId: PropTypes.string,
+  // onWithdraw: PropTypes.func,
+  // sessionId: PropTypes.string,
   t: PropTypes.func.isRequired,
 }
 
 SidebarContainer.defaultProps = {
-  companyName: '',
-  onAnticipate: null,
-  onWithdraw: null,
-  sessionId: '',
+  // companyName: '',
+  // onAnticipate: null,
+  // onWithdraw: null,
+  // sessionId: '',
 }
 
 export default SidebarContainer

--- a/packages/pilot/src/pages/LoggedArea/index.js
+++ b/packages/pilot/src/pages/LoggedArea/index.js
@@ -69,8 +69,10 @@ const LoggedArea = ({
       <Redirect
         to={
           recipientId
-          ? `/balance/${recipientId}`
-          : '/balance/'
+          // ? `/balance/${recipientId}`
+          // : '/balance/'
+          ? `/recipients/${recipientId}`
+          : '/recipients'
         }
       />
     </Switch>

--- a/packages/pilot/src/pages/LoggedArea/routes.js
+++ b/packages/pilot/src/pages/LoggedArea/routes.js
@@ -1,13 +1,13 @@
 import Balance32 from 'emblematic-icons/svg/Extract32.svg'
 import Configuration32 from 'emblematic-icons/svg/Configuration32.svg'
-import Transaction32 from 'emblematic-icons/svg/Transaction32.svg'
+// import Transaction32 from 'emblematic-icons/svg/Transaction32.svg'
 import Withdraw32 from 'emblematic-icons/svg/Withdraw32.svg'
 import Store32 from 'emblematic-icons/svg/Store32.svg'
 
-import { Balance } from '../Balance'
+// import { Balance } from '../Balance'
 import { Anticipation } from '../Anticipation'
-import CompanySettings from '../CompanySettings'
-import Transactions from '../Transactions'
+// import CompanySettings from '../CompanySettings'
+// import Transactions from '../Transactions'
 import UserSettings from '../UserSettings'
 import Withdraw from '../Withdraw'
 import Recipients from '../Recipients'
@@ -30,27 +30,27 @@ export default {
     path: '/anticipation/:id?',
     title: 'pages.anticipation.title',
   },
-  balance: {
-    component: Balance,
-    exact: true,
-    icon: Balance32,
-    path: '/balance/:id?',
-    title: 'pages.balance.title',
-  },
-  transactions: {
-    component: Transactions,
-    exact: true,
-    icon: Transaction32,
-    path: '/transactions',
-    title: 'pages.transactions.title',
-  },
-  companySettings: {
-    component: CompanySettings,
-    exact: true,
-    icon: Configuration32,
-    path: '/settings',
-    title: 'pages.settings.company.menu',
-  },
+  // balance: {
+  //   component: Balance,
+  //   exact: true,
+  //   icon: Balance32,
+  //   path: '/balance/:id?',
+  //   title: 'pages.balance.title',
+  // },
+  // transactions: {
+  //   component: Transactions,
+  //   exact: true,
+  //   icon: Transaction32,
+  //   path: '/transactions',
+  //   title: 'pages.transactions.title',
+  // },
+  // companySettings: {
+  //   component: CompanySettings,
+  //   exact: true,
+  //   icon: Configuration32,
+  //   path: '/settings',
+  //   title: 'pages.settings.company.menu',
+  // },
   transactionsDetails: {
     exact: true,
     hidden: true,


### PR DESCRIPTION
## Contexto
Este PR comenta alguns códigos do `Sidebar` container e algumas rotas do arquivo de `routes.js`. Estes códigos comentados são para o lançamento da dash de recebedores para teste que será enviado para alguns clientes. Dessa forma acreditamos que direcionaremos o usuário a focar somente nas telas novas de Recebedores (Listagem, Adição e Detalhes de recebedores). E com isso os feedbacks são direcionados para essas três funcionalidades.

Segue link do Card: https://github.com/pagarme/caesar/issues/342

## Checklist
- [x] Somente o link de Recebedores funcionando e sendo apresentado no `Sidebar`

## Screenshots
![image](https://user-images.githubusercontent.com/20197808/55577401-e7edc980-56e9-11e9-9a1f-8e600badf88f.png)

## Como testar?
- `git clone` neste repositório
- `yarn install` para puxar todas as dependências
- `yarn start` para rodar a tela local
