### PR TITLE
Extrato - Corrige valor líquido de solicitações recentes

### DIFF
--- a/packages/cockpit/src/bulkAnticipations/index.js
+++ b/packages/cockpit/src/bulkAnticipations/index.js
@@ -20,6 +20,7 @@ const calculateRequestAmount = pipe(
 
 export const buildPendingRequest = map(applySpec({
   amount: calculateRequestAmount,
+  automaticTransfer: prop('automatic_transfer'),
   created_at: prop('date_created'),
   id: prop('id'),
   payment_date: prop('payment_date'),

--- a/packages/pilot/src/containers/Balance/index.js
+++ b/packages/pilot/src/containers/Balance/index.js
@@ -202,17 +202,30 @@ class Balance extends Component {
 
   getPendingRequest ({
     amount,
+    automaticTransfer,
     created_at, // eslint-disable-line camelcase
     status,
     type,
   }) {
-    const { t } = this.props
+    const {
+      company: { pricing },
+      t,
+    } = this.props
+
     const { statuses, types } = bulkAnticipationsLabels
     const title =
       `${t(types[type])} ${t(statuses[status])}` || '-'
 
+    const ted = pricing
+      ? path(['transfers', 'ted'], pricing)
+      : 0
+
+    const netAmount = automaticTransfer
+      ? amount - ted
+      : amount
+
     return {
-      amount: currencyFormatter(amount),
+      amount: currencyFormatter(netAmount),
       created_at: dateFormatter(created_at),
       title,
     }


### PR DESCRIPTION
## Contexto
Este PR corrige o card de `Solicitações Recentes` na tela de extrato, que atualmente exibe o valor sem descontar a taxa de transferência (quando automática)

## Checklist
- [x] Adiciona a prop `automaticTransfer` no Cockpit
- [x] Utiliza a prop `automaticTransfer` para calcular o valor líquido na tela de Extrato

## Issues linkadas
- [x] Resolves https://github.com/pagarme/pilot/issues/1145

### Preview

- Resposta da API

  ![image](https://user-images.githubusercontent.com/18339615/55899666-c3876680-5b9b-11e9-95af-c2eac4d483c4.png)

- Exibição na Pilot

  ![image](https://user-images.githubusercontent.com/18339615/55899701-d601a000-5b9b-11e9-8d0d-1a6a52b08a0b.png)

## Como testar?
1. Crie uma antecipação habilitando a transferência automática
2. Confirme se o valor líquido no formulário de antecipação é igual ao valor exibido em extrato