### PR TITLE
PR - Add alerta de saída de fluxo (modal)

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -70,6 +70,12 @@
   "of": "de",
   "password": "Senha",
   "password_confirm": "Confirmar senha",
+  "prompt": {
+    "title": "Atenção!",
+    "message": "Tem certeza que deseja cancelar o fluxo atual? Todas as informações serão perdidas.",
+    "confirm": "Sim, quero sair",
+    "deny": "Não quero sair"
+  },
   "recipient": "Recebedor",
   "transaction": "Transação",
   "try_again": "Tentar novamente",

--- a/packages/pilot/src/App.js
+++ b/packages/pilot/src/App.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { ThemeProvider } from 'former-kit'
 import theme from 'former-kit-skin-pagarme'
-import { HashRouter } from 'react-router-dom'
 import { Provider as StateProvider } from 'react-redux'
+import HashRouterWithPrompt from './HashRouterWithPrompt'
 
 import store from './configureStore'
 import Root from './pages/Root'
@@ -10,9 +10,9 @@ import Root from './pages/Root'
 const App = () => (
   <ThemeProvider theme={theme}>
     <StateProvider store={store}>
-      <HashRouter>
+      <HashRouterWithPrompt>
         <Root />
-      </HashRouter>
+      </HashRouterWithPrompt>
     </StateProvider>
   </ThemeProvider>
 )

--- a/packages/pilot/src/HashRouterWithPrompt.js
+++ b/packages/pilot/src/HashRouterWithPrompt.js
@@ -1,0 +1,88 @@
+import React, { Component, Fragment } from 'react'
+import PropTypes from 'prop-types'
+
+import { compose } from 'ramda'
+import { HashRouter } from 'react-router-dom'
+import { Spacing } from 'former-kit'
+import { translate } from 'react-i18next'
+
+import ConfirmModal from './components/ConfirmModal'
+import style from './style.css'
+
+const enhanced = compose(translate())
+
+class HashRouterWithPrompt extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      callback: null,
+      message: null,
+    }
+
+    this.getUserConfirmation = this.getUserConfirmation.bind(this)
+    this.handleClick = this.handleClick.bind(this)
+    this.handleConfirmationClick = this.handleClick.bind(this, true)
+    this.handleCancelClick = this.handleClick.bind(this, false)
+  }
+
+  getUserConfirmation (message, callback) {
+    this.setState({
+      callback,
+      message,
+    })
+  }
+
+  handleClick (isValid) {
+    const { callback } = this.state
+    callback(isValid)
+    this.setState({
+      callback: null,
+      message: null,
+    })
+  }
+
+  render () {
+    const {
+      children,
+      t,
+    } = this.props
+    const {
+      callback,
+      message,
+    } = this.state
+
+    return (
+      <Fragment>
+        {(callback && message)
+          && (
+            <ConfirmModal
+              isOpen
+              onCancel={this.handleCancelClick}
+              onConfirm={this.handleConfirmationClick}
+              title={t('prompt.title')}
+              cancelText={t('prompt.deny')}
+              confirmText={t('prompt.confirm')}
+            >
+              <Spacing />
+              <div className={style.messageContainer}>
+                {t('prompt.message')}
+              </div>
+              <Spacing />
+            </ConfirmModal>
+          )
+        }
+        <HashRouter getUserConfirmation={this.getUserConfirmation}>
+          {children}
+        </HashRouter>
+      </Fragment>
+    )
+  }
+}
+
+HashRouterWithPrompt.propTypes = {
+  children: PropTypes.node.isRequired,
+  t: PropTypes.func.isRequired,
+}
+
+export default enhanced(HashRouterWithPrompt)

--- a/packages/pilot/src/containers/AddRecipient/index.js
+++ b/packages/pilot/src/containers/AddRecipient/index.js
@@ -8,7 +8,6 @@ import ConfigurationStep from './ConfigurationStep'
 import ConfirmStep from './ConfirmStep'
 import ConclusionStep from './ConclusionStep'
 import ErrorStep from './ErrorStep'
-import ConfirmModal from '../../components/ConfirmModal'
 import Loader from '../../components/Loader'
 import style from './style.css'
 
@@ -48,11 +47,9 @@ class AddRecipients extends Component {
       error,
       fetchData: {},
       isLoading: false,
-      openModal: false,
       stepsStatus: initialStepStatus,
     }
 
-    this.closeExitModal = this.closeExitModal.bind(this)
     this.createNewStepStatus = this.createNewStepStatus.bind(this)
     this.createSteps = this.createSteps.bind(this)
     this.fetchAndSetNextStepData = this.fetchAndSetNextStepData.bind(this)
@@ -63,7 +60,6 @@ class AddRecipients extends Component {
     this.handleNextStep = this.handleNextStep.bind(this)
     this.handleTryAgain = this.handleTryAgain.bind(this)
     this.handleViewDetails = this.handleViewDetails.bind(this)
-    this.openExitModal = this.openExitModal.bind(this)
     this.renderError = this.renderError.bind(this)
     this.renderStep = this.renderStep.bind(this)
 
@@ -229,14 +225,6 @@ class AddRecipients extends Component {
     })
   }
 
-  openExitModal () {
-    this.setState({ openModal: true })
-  }
-
-  closeExitModal () {
-    this.setState({ openModal: false })
-  }
-
   renderStep () {
     const {
       currentStepNumber,
@@ -258,7 +246,7 @@ class AddRecipients extends Component {
       ...options,
       data: data[currentStep.id],
       onBack: this.handleBackNavigation,
-      onCancel: this.openExitModal,
+      onCancel: onExit,
       onContinue: this.handleContinueNavigation,
       onEdit: this.handleEdit,
       onExit,
@@ -310,14 +298,8 @@ class AddRecipients extends Component {
       currentStepNumber,
       error,
       isLoading,
-      openModal,
       stepsStatus,
     } = this.state
-
-    const {
-      onExit,
-      t,
-    } = this.props
 
     const isConclusion = this.steps[currentStepNumber].id === CONCLUSION
     const shouldRemoveCardBorder = (error || isConclusion)
@@ -342,18 +324,6 @@ class AddRecipients extends Component {
               : this.renderStep()
           }
         </Card>
-        <ConfirmModal
-          isOpen={openModal}
-          onCancel={this.closeExitModal}
-          onConfirm={onExit}
-          title={t('pages.add_recipient.cancel_recipient_creation')}
-          cancelText={t('pages.add_recipient.no_keep')}
-          confirmText={t('pages.add_recipient.yes_cancel')}
-        >
-          <p className={style.centerText}>
-            {t('pages.add_recipient.cancel_recipient_message')}
-          </p>
-        </ConfirmModal>
       </Fragment>
     )
   }

--- a/packages/pilot/src/style.css
+++ b/packages/pilot/src/style.css
@@ -1,0 +1,3 @@
+.messageContainer {
+  text-align: center;
+}


### PR DESCRIPTION
## Contexto
Atualmente quando estamos em qualquer fluxo na pilot (adição de recebedor, antecipação, etc) é possível sair quando o usuário clica em qualquer botão no Sidebar sem nenhum aviso de alerta de saída de fluxo.

Este PR adiciona este alerta que é um `Prompt` do `react-router-dom`. Este component está numa HOC e faz parte deste card aqui: https://github.com/pagarme/caesar/issues/349

## Checklist
- [x] Fazer o Prompt aceitar um modal como alerta.
- [x] Fazer o modal aceitar qualquer mensagem como filho dentro dele.
- [x] Aplicar funcionalidades de confirmar e cancelar no modal.

## Screenshots
![image](https://user-images.githubusercontent.com/20197808/57549391-c790da80-7339-11e9-9fca-bf9807d2cd30.png)

## Como testar?
- `git clone` nesta repo
- `yarn` para instalar todas as dependências
- `yarn start` para rodar local.

## Atenção
- Ao adicionar um novo recebedor, passar do primeiro passo para testar se o modal está funcionando.
- Testar se o cancelar de um fluxo não chama o modal de alerta. O modal de alerta só deve ser chamado quando clicado em algum link no Sidebar.
