### PR TITLE
PR: Fix de small issues encontradas na Dash de Recebedores

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -791,7 +791,7 @@
       "configurations": "configurações",
       "count": "Número de recebedores",
       "date_created": "Data de criação",
-      "date_updated": "Data da atualização",
+      "date_updated": "Última atualização",
       "details": "Detalhes",
       "balance": "extrato",
       "ID": "ID",

--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -807,7 +807,7 @@
         "affiliation": "AF",
         "blocked": "TB",
         "inactive": "PD",
-        "paid": "P",
+        "processing": "PR",
         "refused": "R",
         "registration": "CR",
         "suspended": "TS"

--- a/packages/pilot/src/containers/Filter/index.js
+++ b/packages/pilot/src/containers/Filter/index.js
@@ -157,6 +157,7 @@ class Filters extends Component {
   renderToolbar () {
     const {
       children,
+      clearFilterDisabled,
       confirmationDisabled,
       disabled,
       onClear,
@@ -195,7 +196,7 @@ class Filters extends Component {
           }
           onClick={onClear}
           fill="outline"
-          disabled={disabled}
+          disabled={clearFilterDisabled || disabled}
         >
           {t('components.filter.reset')}
         </Button>
@@ -325,6 +326,7 @@ class Filters extends Component {
 
 Filters.propTypes = {
   children: PropTypes.node.isRequired,
+  clearFilterDisabled: PropTypes.bool,
   confirmationDisabled: PropTypes.bool,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
@@ -343,6 +345,7 @@ Filters.propTypes = {
 }
 
 Filters.defaultProps = {
+  clearFilterDisabled: false,
   confirmationDisabled: false,
   disabled: false,
   onChange: () => null,

--- a/packages/pilot/src/containers/RecipientDetails/index.js
+++ b/packages/pilot/src/containers/RecipientDetails/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import {
   Card,
   CardContent,
-  Legend,
   TabBar,
   TabItem,
 } from 'former-kit'
@@ -13,6 +12,7 @@ import Configuration from './Config'
 import Balance from './Balance'
 import styles from './styles.css'
 import dateFormatter from '../../formatters/longDate'
+import StatusLegend from '../RecipientTable/statusLegend'
 
 class RecipientDetails extends Component {
   constructor (props) {
@@ -56,13 +56,13 @@ class RecipientDetails extends Component {
               <div className={styles.status}>
                 <span className={styles.label}>{t('pages.recipients.status')}</span>
                 <div className={styles.statusLegend}>
-                  <Legend
-                    color="#17c9b2"
-                    acronym={recipient.status}
-                    hideLabel
+                  <StatusLegend
+                    item={recipient}
+                    isAcronym={false}
+                    t={t}
                   >
                     {t('pages.recipients.active')}
-                  </Legend>
+                  </StatusLegend>
                 </div>
               </div>
             </div>

--- a/packages/pilot/src/containers/RecipientTable/index.js
+++ b/packages/pilot/src/containers/RecipientTable/index.js
@@ -5,6 +5,8 @@ import AddIcon from 'emblematic-icons/svg/Add32.svg'
 import IconInfo from 'emblematic-icons/svg/Info32.svg'
 import Search32 from 'emblematic-icons/svg/Search32.svg'
 
+import { pick } from 'ramda'
+
 import {
   Alert,
   Button,
@@ -25,6 +27,7 @@ import Filter from '../Filter'
 import tableColumns from './tableColumns'
 
 const RecipientTable = ({
+  confirmationDisabled,
   expandedRows,
   filterOptions,
   loading,
@@ -32,6 +35,7 @@ const RecipientTable = ({
   onExpandRow,
   onFilterChange,
   onFilterClear,
+  onFilterConfirm,
   onOrderChange,
   onPageChange,
   onRowClick,
@@ -41,6 +45,7 @@ const RecipientTable = ({
     total,
   },
   push,
+  query,
   rows,
   selectedRows,
   t,
@@ -61,10 +66,13 @@ const RecipientTable = ({
           tv={12}
         >
           <Filter
+            confirmationDisabled={confirmationDisabled}
             disabled={loading}
-            onConfirm={onFilterChange}
+            onConfirm={onFilterConfirm}
+            onChange={onFilterChange}
             onClear={onFilterClear}
             options={filterOptions}
+            query={pick(['filters', 'search'], query)}
             t={t}
           >
             <Input
@@ -160,6 +168,7 @@ const RecipientTable = ({
 }
 
 RecipientTable.propTypes = {
+  confirmationDisabled: PropTypes.bool,
   expandedRows: PropTypes.arrayOf(PropTypes.number).isRequired,
   filterOptions: PropTypes.arrayOf(PropTypes.shape({
     items: PropTypes.arrayOf(PropTypes.shape({
@@ -174,6 +183,7 @@ RecipientTable.propTypes = {
   onExpandRow: PropTypes.func.isRequired,
   onFilterChange: PropTypes.func.isRequired,
   onFilterClear: PropTypes.func.isRequired,
+  onFilterConfirm: PropTypes.func.isRequired,
   onOrderChange: PropTypes.func.isRequired,
   onPageChange: PropTypes.func.isRequired,
   onRowClick: PropTypes.func.isRequired,
@@ -183,6 +193,10 @@ RecipientTable.propTypes = {
     total: PropTypes.number,
   }).isRequired,
   push: PropTypes.func.isRequired,
+  query: PropTypes.shape({
+    properties: PropTypes.object,
+    search: PropTypes.string,
+  }),
   rows: PropTypes.arrayOf(PropTypes.shape({
     anticipatable_volume_percentage: PropTypes.number,
     automatic_anticipation_days: PropTypes.string,
@@ -203,6 +217,14 @@ RecipientTable.propTypes = {
   })).isRequired,
   selectedRows: PropTypes.arrayOf(PropTypes.number).isRequired,
   t: PropTypes.func.isRequired,
+}
+
+RecipientTable.defaultProps = {
+  confirmationDisabled: false,
+  query: {
+    properties: {},
+    search: '',
+  },
 }
 
 export default RecipientTable

--- a/packages/pilot/src/containers/RecipientTable/index.js
+++ b/packages/pilot/src/containers/RecipientTable/index.js
@@ -27,6 +27,7 @@ import Filter from '../Filter'
 import tableColumns from './tableColumns'
 
 const RecipientTable = ({
+  clearFilterDisabled,
   confirmationDisabled,
   expandedRows,
   filterOptions,
@@ -66,6 +67,7 @@ const RecipientTable = ({
           tv={12}
         >
           <Filter
+            clearFilterDisabled={clearFilterDisabled}
             confirmationDisabled={confirmationDisabled}
             disabled={loading}
             onConfirm={onFilterConfirm}
@@ -168,6 +170,7 @@ const RecipientTable = ({
 }
 
 RecipientTable.propTypes = {
+  clearFilterDisabled: PropTypes.bool,
   confirmationDisabled: PropTypes.bool,
   expandedRows: PropTypes.arrayOf(PropTypes.number).isRequired,
   filterOptions: PropTypes.arrayOf(PropTypes.shape({
@@ -220,6 +223,7 @@ RecipientTable.propTypes = {
 }
 
 RecipientTable.defaultProps = {
+  clearFilterDisabled: false,
   confirmationDisabled: false,
   query: {
     properties: {},

--- a/packages/pilot/src/containers/RecipientTable/statusLegend.js
+++ b/packages/pilot/src/containers/RecipientTable/statusLegend.js
@@ -5,23 +5,36 @@ import { Legend } from 'former-kit'
 import style from './style.css'
 import status from '../../models/recipientStatusLegends'
 
-const StatusLegend = ({ item, t }) => (
-  <div className={style.centralizedItem}>
-    <Legend
-      color={status[item.status].color}
-      acronym={t(`pages.recipients.status_acronym_of.${item.status}`)}
-      hideLabel
-    >
-      {t(`pages.recipients.status_of.${item.status}`)}
-    </Legend>
-  </div>
-)
+const StatusLegend = ({
+  isAcronym,
+  item,
+  t,
+}) => {
+  const localePath = isAcronym
+    ? 'pages.recipients.status_acronym_of'
+    : 'pages.recipients.status_of'
+
+  return (
+    <div className={style.centralizedItem}>
+      <Legend
+        color={status[item.status].color}
+        acronym={t(`${localePath}.${item.status}`)}
+        hideLabel
+      >
+        {t(`pages.recipients.status_of.${item.status}`)}
+      </Legend>
+    </div>
+  )
+}
 
 StatusLegend.propTypes = {
-  item: PropTypes.shape({
-    status: PropTypes.string,
-  }).isRequired,
+  isAcronym: PropTypes.bool,
+  item: PropTypes.string.isRequired,
   t: PropTypes.func.isRequired,
+}
+
+StatusLegend.defaultProps = {
+  isAcronym: false,
 }
 
 export default StatusLegend

--- a/packages/pilot/src/containers/RecipientTable/tableColumns.js
+++ b/packages/pilot/src/containers/RecipientTable/tableColumns.js
@@ -77,6 +77,7 @@ const getDefaultColumns = ({
     orderable: false,
     renderer: item => (
       <StatusLegend
+        isAcronym
         item={item}
         t={t}
       />

--- a/packages/pilot/src/containers/RecipientTable/tableColumns.js
+++ b/packages/pilot/src/containers/RecipientTable/tableColumns.js
@@ -9,7 +9,6 @@ import {
   Col,
   Row,
   Grid,
-  Truncate,
 } from 'former-kit'
 
 import formatDate from '../../formatters/longDate'
@@ -87,12 +86,6 @@ const getDefaultColumns = ({
   {
     accessor: ['id'],
     orderable: false,
-    renderer: recipient => (
-      <Truncate
-        resizableByWindow
-        text={recipient.id}
-      />
-    ),
     title: t('pages.recipients.id'),
   },
   {
@@ -103,12 +96,6 @@ const getDefaultColumns = ({
   {
     accessor: ['bank_account', 'legal_name'],
     orderable: false,
-    renderer: recipient => (
-      <Truncate
-        resizableByWindow
-        text={recipient.bank_account.legal_name}
-      />
-    ),
     title: t('pages.recipients.bank_account_legal_name'),
   },
   {

--- a/packages/pilot/src/models/recipientStatusLegends.js
+++ b/packages/pilot/src/models/recipientStatusLegends.js
@@ -11,8 +11,8 @@ const status = {
   inactive: {
     color: '#613fc7',
   },
-  paid: {
-    color: '#17c9b2',
+  processing: {
+    color: '#561e6a',
   },
   refused: {
     color: '#da272c',

--- a/packages/pilot/src/pages/Recipients/Search/Search.js
+++ b/packages/pilot/src/pages/Recipients/Search/Search.js
@@ -104,11 +104,10 @@ class RecipientsSearch extends React.Component {
     const urlSearchQuery = props.history.location.search
 
     this.state = {
+      clearFilterDisabled: false,
       confirmationDisabled: false,
       expandedRows: [],
-      query: isEmpty(urlSearchQuery)
-        ? props.query
-        : parseQueryUrl(urlSearchQuery),
+      query: props.query || parseQueryUrl(urlSearchQuery),
       result: {
         chart: {
           dataset: [],
@@ -142,15 +141,6 @@ class RecipientsSearch extends React.Component {
       this.updateQuery(this.props.query)
     } else {
       this.requestData(parseQueryUrl(urlSearchQuery))
-    }
-  }
-
-  componentWillReceiveProps (nextProps) {
-    const { location: { search } } = this.props
-    const { location } = nextProps
-
-    if (search !== location.search) {
-      this.requestData(parseQueryUrl(location.search))
     }
   }
 
@@ -286,16 +276,19 @@ class RecipientsSearch extends React.Component {
 
   handleFilterClear () {
     this.setState({
-      confirmationDisabled: false,
+      clearFilterDisabled: true,
+      confirmationDisabled: true,
+      query: initialState.query,
     })
 
-    this.updateQuery({ initialState })
+    this.updateQuery(initialState.query)
   }
 
   handleFilterChange (query) {
     const newQuery = mergeRight(this.state.query, query)
 
     this.setState({
+      clearFilterDisabled: true,
       confirmationDisabled: false,
       query: newQuery,
     })
@@ -311,6 +304,11 @@ class RecipientsSearch extends React.Component {
       offset: 1,
       search,
     }
+
+    this.setState({
+      clearFilterDisabled: false,
+      confirmationDisabled: true,
+    })
 
     this.updateQuery(query)
   }
@@ -359,6 +357,7 @@ class RecipientsSearch extends React.Component {
 
   render () {
     const {
+      clearFilterDisabled,
       collapsed,
       columns,
       confirmationDisabled,
@@ -396,6 +395,7 @@ class RecipientsSearch extends React.Component {
         collapsed={collapsed}
         columns={columns}
         count={0}
+        clearFilterDisabled={clearFilterDisabled}
         confirmationDisabled={confirmationDisabled}
         dateSelectorPresets={dateSelectorPresets}
         expandedRows={expandedRows}

--- a/packages/pilot/src/pages/Recipients/Search/reducer.js
+++ b/packages/pilot/src/pages/Recipients/Search/reducer.js
@@ -3,7 +3,7 @@ import {
   SEARCH_RECEIVE,
 } from './actions'
 
-const initialState = {
+export const initialState = {
   loading: true,
   query: {
     count: 15,

--- a/packages/pilot/stories/containers/RecipientDetails/index.js
+++ b/packages/pilot/stories/containers/RecipientDetails/index.js
@@ -11,7 +11,7 @@ const mockRecipient = {
   hash: 'rj_qwedaefsdfwerasfgwtwetwe',
   id: '12345678',
   name: 'Nome da Company LTDA',
-  status: 'Ativo',
+  status: 'active',
 }
 
 const mockInformation = {
@@ -157,6 +157,7 @@ const RecipientDetailsExample = () => (
         configurationProps={mockConfiguration}
         balanceProps={mockBalance}
         recipient={mockRecipient}
+        isAcronym={false}
       />
     </Card>
   </Section>


### PR DESCRIPTION
## Contexto
Este PR corrige alguns problemas encontrados na dash de recebedores. Os erros foram detectados um pouco antes de lançarmos o segundo link para teste em cliente. Ele junta erros encontrados internamente e feedbacks de nossos clientes.

Este PR faz parte deste card: https://github.com/pagarme/caesar/issues/361

## Checklist
- [x] Guardar o valor do Search após aplicado. Ao mudar de tela, o valor deve permanecer no Search.
- [x] Alterar os nomes dos status dos recebedores para português, temos essas traduções já feitas. 
- [x] Ajustar as cores dos status da listagem com o detalhes do recebedor.
- [x] No expansível da tabela, alterar o nome `Data da atualização` para `Última atualização`

## Screenshots
Guardando o valor de busca no `state` para que a busca não seja perdida após a mudança de tela:
![Peek 2019-06-03 17-23](https://user-images.githubusercontent.com/20197808/58832398-3acdf980-8625-11e9-8e39-54c9484c545b.gif)

Traduzindo o status:
![image](https://user-images.githubusercontent.com/20197808/58832430-47eae880-8625-11e9-9d9d-2850e62155c5.png)

## Como testar?
- `git clone` deste repo
- `yarn` para baixar todas as dependências
- `yarn start` para rodar local
