### PR TITLE
antecipation: update translate

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -762,7 +762,7 @@
     "recipients": {
       "add": "Adicionar recebedor",
       "active": "ativo",
-      "anticipatable_volume_percentage": "Volume antecipado",
+      "anticipatable_volume_percentage": "Volume antecipável",
       "anticipation_model": "Modelo",
       "anticipation_model_of": {
         "manual": "Manual por Volume",


### PR DESCRIPTION
## Contexto
Este PR visa corrigir o arquivo de translate. Mudar o termo `Volume antecipado` para `Volume antecipável`.

Faz parte desse card: https://github.com/pagarme/caesar/issues/363

## Checklist
- [x] Mudar o termo `Volume antecipado` para `Volume antecipável`

## Screenshots
![image](https://user-images.githubusercontent.com/20197808/59479873-dbe25e80-8e34-11e9-9119-86861da4583e.png)

## Como testar?
- `git clone` nesse repo
- `yarn` para instalar as dependências
- `yarn start` para rodar local