### PR TITLE
release 0.14.2 - 17/06/2019

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -568,6 +568,8 @@
       "no_connection": "Por favor verifique sua conexão com a internet e recarrege a página",
       "no_connection_title": "Sem internet?",
       "page_refresh": "Recarregar página",
+      "pending_risk_analysis": "Nos próximos dias você receberá um e-mail habilitando o acesso à Dashboard",
+      "pending_risk_analysis_title": "Olá, estamos analisando a sua conta",
       "rate_limit_message": "Limite de acessos excedido. Tente novamente mais tarde",
       "rate_limit_title": "Limite de acessos",
       "unauthorized": "Parece que sua sessão expirou",

--- a/packages/pilot/src/errors/index.js
+++ b/packages/pilot/src/errors/index.js
@@ -6,6 +6,7 @@ import transactions from './transactions'
 import react from './react'
 import anticipation from './anticipation'
 import recipient from './recipient'
+import pendingRiskAnalysis from './pendingRiskAnalysis'
 
 export default flatten([
   anticipation,
@@ -15,4 +16,5 @@ export default flatten([
   transactions,
   react,
   recipient,
+  pendingRiskAnalysis,
 ])

--- a/packages/pilot/src/errors/pendingRiskAnalysis.js
+++ b/packages/pilot/src/errors/pendingRiskAnalysis.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import GenericError from '../pages/Errors/GenericError'
+
+export default [
+  {
+    affectedRoutes: [/./],
+    getComponent: localized => (
+      <GenericError
+        {...localized}
+      />
+    ),
+    localized: t => ({
+      message: t('pages.error.pending_risk_analysis'),
+      title: t('pages.error.pending_risk_analysis_title'),
+    }),
+    message: /Pending risk analysis/,
+    method: /./,
+    name: /./,
+    status: /./,
+    type: /unknown/,
+  },
+]

--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -37,6 +37,8 @@ import { receiveError } from '../../ErrorBoundary'
 import { activeCompanyLogin, inactiveCompanyLogin } from '../../../vendor/googleTagManager'
 
 const isActiveCompany = propEq('status', 'active')
+const isSelfRegister = propEq('type', 'self_register')
+const isPendingRiskAnalysis = propEq('status', 'pending_risk_analysis')
 
 const getRecipientId = pathOr(null, ['account', 'company', 'default_recipient_id', env])
 
@@ -102,6 +104,14 @@ const accountEpic = action$ =>
     )
 
 const verifyEnvironmentPermission = (company) => {
+  if (
+    env === 'live' &&
+    isSelfRegister(company) &&
+    isPendingRiskAnalysis(company)
+  ) {
+    throw new Error('Pending risk analysis')
+  }
+
   if (env === 'live' && !isActiveCompany(company)) {
     throw new Error('Unauthorized environment')
   }


### PR DESCRIPTION
## Fixed date 17/06/2019
### Contexto
Para validar esse pull request acesse os links onde esta versão foi publicada
Essa release tem como objetivo principal adicionar o erro personalizado para companies do tipo `self_register` com o status `pending_risk_analysis`

### esta versão inclui:
- errors: add pending risk analysis error #1256

### checklist
- acessar a pilot com uma company que foi gerada a partir do cadastro do autocredenciamento com o template de `self_register`
- verificar se a modal com o erro customizado avisando para o cliente que está aguardando aprovação é exibida

resolves #1258
