### PR TITLE
account: refactor to handle with autocred companies.

### DIFF
--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -9,6 +9,7 @@ import {
   mergeMap,
   tap,
 } from 'rxjs/operators'
+import { of as rxOf } from 'rxjs'
 import { combineEpics, ofType } from 'redux-observable'
 import cockpit from 'cockpit'
 import env from '../../../environment'
@@ -132,12 +133,12 @@ const companyEpic = (action$, state$) => action$.pipe(
         payload: errorPayload,
       }))
   }),
-  map(({ error, payload }) => {
-    if (error) {
-      return receiveError(payload)
+  mergeMap((action) => {
+    if (action.error) {
+      return rxOf(receiveError(action.payload))
     }
 
-    return receiveCompany(payload)
+    return rxOf(receiveCompany(action))
   }),
   tap(({ error, payload }) => {
     if (error) {


### PR DESCRIPTION
## Contexto
Atualmente temos um problema com o login de um lojista que vem como `self_register`, a primeira vez que ele loga é mostrado um modal informando que faltam alguns detalhes, na segunda vez esse modal não é mostrado.

## Checklist
- [x] Quando o lojista realizar login ele deve receber o alerta e voltar para o login.
- [x] Quando o lojista refazer o login ele deve receber novamente o alerta.
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [x] Resolves pagarme/credenciamento#214
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Screenshots
![login-error](https://user-images.githubusercontent.com/6943919/62302461-c6f77400-b450-11e9-89f5-db95a013bace.gif)

## Como testar?
1. Crie uma conta com o token de self_register e confirme a sua conta.
2. Inicie a pilot em modo live: `env REACT_APP_API_ENVIRONMENT=live yarn start`
3. Faça login usando sua conta.