### PR TITLE
PR: update URL validation

### DIFF
--- a/packages/pilot/src/validation/protocol.js
+++ b/packages/pilot/src/validation/protocol.js
@@ -2,7 +2,7 @@ import isUrl from 'validator/lib/isURL'
 
 const options = {
   protocols: ['http', 'https'],
-  require_protocol: true,
+  require_protocol: false,
 }
 
 export default message => value => (!value || !isUrl(value, options)) && message


### PR DESCRIPTION
## Contexto
Atualmente, quando adicionamos um novo recebedor, não é possível adicionar uma url válida apenas com `www`, sem `http` ou `https`.

Este PR atualiza a validação de protocolo tornando possível a adição de um site com um `www`. Exemplo: `www.site.com.br`

Issue relacionada: [Caesar #433](https://github.com/pagarme/caesar/issues/433)

## Screenshots
Caso de erro:
![image](https://user-images.githubusercontent.com/20197808/67029014-c7fc8100-f0e2-11e9-908d-ba026bcef583.png)

Casos de acerto:
![image](https://user-images.githubusercontent.com/20197808/66959319-7d2a2d00-f040-11e9-84a7-46c38ace7a24.png)

![image](https://user-images.githubusercontent.com/20197808/66959211-48b67100-f040-11e9-8dc9-cb96ca95c413.png)

![image](https://user-images.githubusercontent.com/20197808/66959254-57048d00-f040-11e9-86f1-b29a9209e955.png)



## Como testar?
- `git clone` para clonar este repositório
- `yarn` para instalar todas as dependências
- `yarn start` para rodar local
- Ir em _Recebedore_ -> clicar no botão de _Adicionar Recebedor_ -> incluir mais informações -> testar as seguintes entradas:
              - `www.site.com.br`
              - `http://www.site.com.br`
              - `https://www.site.com.br`
              - `http://site.com.br`