### PR TITLE
Refactor de labels do container Detalhes da Transação

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -1249,6 +1249,11 @@
     "transaction": {
       "acquirer_name": "Operadora do cartão",
       "acquirer_response_code": "Resposta da operadora",
+      "action_boleto": "Gerar boleto",
+      "action_capture": "Capturar",
+      "action_refund":"Estornar",
+      "action_reprocess": "Reprocessar",
+      "action_reprocessing": "Reprocessando",
       "alert": {
         "chargeback_reason": "Motivo do chargeback:",
         "pending_review": "Existe {{count}} transação pendente de revisão.",

--- a/packages/pilot/src/containers/TransactionDetails/index.js
+++ b/packages/pilot/src/containers/TransactionDetails/index.js
@@ -283,6 +283,7 @@ class TransactionDetails extends Component {
 
   getActions () {
     const {
+      actionLabels,
       headerLabels,
       loading: {
         reprocess,
@@ -307,14 +308,14 @@ class TransactionDetails extends Component {
       icon: <CaptureIcon width={12} height={12} />,
       onClick: onCapture,
       title: method === 'boleto' && capabilities.capturable
-        ? 'Gerar boleto'
-        : 'Capturar',
+        ? actionLabels.boleto
+        : actionLabels.capture,
     }
 
     const onExportAction = {
       icon: <DownloadIcon width={12} height={12} />,
       onClick: onExport,
-      title: 'Exportar',
+      title: actionLabels.export,
     }
 
     const onReprocessAction = {
@@ -322,14 +323,14 @@ class TransactionDetails extends Component {
       loading: reprocess,
       onClick: onReprocess,
       title: reprocess
-        ? 'Reprocessando'
-        : 'Reprocessar',
+        ? actionLabels.reprocessing
+        : actionLabels.reprocess,
     }
 
     const onRefundAction = {
       icon: <IconReverse width={12} height={12} />,
       onClick: onRefund,
-      title: 'Estornar',
+      title: actionLabels.refund,
     }
 
     const getManualReviewTransactionActions = (trx) => {
@@ -969,6 +970,14 @@ class TransactionDetails extends Component {
 }
 
 TransactionDetails.propTypes = {
+  actionLabels: PropTypes.shape({
+    boleto: PropTypes.string,
+    capture: PropTypes.string,
+    export: PropTypes.string,
+    refund: PropTypes.string,
+    reprocess: PropTypes.string,
+    reprocessing: PropTypes.string,
+  }).isRequired,
   alertLabels: PropTypes.shape({
     chargeback_reason: PropTypes.string,
     chargeback_reason_label: PropTypes.string,

--- a/packages/pilot/src/pages/Transactions/Details/Details.js
+++ b/packages/pilot/src/pages/Transactions/Details/Details.js
@@ -95,6 +95,15 @@ const copyToClipBoard = (text) => {
   /* eslint-enable no-undef */
 }
 
+const getActionLabels = t => ({
+  boleto: t('pages.transaction.action_boleto'),
+  capture: t('pages.transaction.action_capture'),
+  export: t('export'),
+  refund: t('pages.transaction.action_refund'),
+  reprocess: t('pages.transaction.action_reprocess'),
+  reprocessing: t('pages.transaction.action_reprocessing'),
+})
+
 const getTransactionDetailsLabels = t => ({
   acquirer_name: t('pages.transaction.acquirer_name'),
   acquirer_response_code: t('pages.transaction.acquirer_response_code'),
@@ -240,6 +249,7 @@ class TransactionDetails extends Component {
     const { t } = this.props
     const formatColumns = getColumnFormatter(t)
     this.state = {
+      actionLabels: getActionLabels(t),
       chargebackRate: 0,
       eventsLabels: getEventsLabels(t),
       expandRecipients: false,
@@ -512,6 +522,7 @@ class TransactionDetails extends Component {
       t,
     } = this.props
     const {
+      actionLabels,
       chargebackRate,
       eventsLabels,
       expandRecipients,
@@ -637,6 +648,7 @@ class TransactionDetails extends Component {
     return (
       <Fragment>
         <TransactionDetailsContainer
+          actionLabels={actionLabels}
           alertLabels={alertLabels}
           atLabel={t('at')}
           boletoWarningMessage={t('pages.transaction.boleto.waiting_payment_warning')}

--- a/packages/pilot/stories/pages/TransactionDetails/index.js
+++ b/packages/pilot/stories/pages/TransactionDetails/index.js
@@ -16,6 +16,15 @@ const t = tr => tr
 
 const formatColumns = getColumnFormatter(t)
 
+const actionLabels = {
+  boleto: 'Gerar boleto',
+  capture: 'Capturar',
+  export: 'Exportar',
+  refund: 'Estornar',
+  reprocess: 'Reprocessar',
+  reprocessing: 'Reprocessando',
+}
+
 const alertLabels = {
   chargeback_reason: 'Motivo do chargeback:',
   reason_code: `Código ${transactionMock.reason_code}`,
@@ -125,6 +134,7 @@ storiesOf('Pages|Transaction', module)
   .add('details', () => (
     <Layout>
       <TransactionDetails
+        actionLabels={actionLabels}
         alertLabels={alertLabels}
         atLabel={t('at')}
         boletoWarningMessage={t('boleto.waiting_payment_warning')}


### PR DESCRIPTION
## Contexto
Este PR altera os labels das `actions` do container `Detalhes da Transação`  para obterem seus títulos de nossas traduções.

## Checklist
- [x] Adicionado novos valores em `translations.json`
- [x] Ações da tela de detalhes da transação utilizam traduções do `i18n`

## Issues linkadas
- [x] Resolves #1421 

## Como testar?
- Entre na branch `refactor/transaction-details`
- Vá até `pilot/packages/pilot` e rode yarn start.
- Vá até `Transações` e selecione as que podem executar as ações:
- `Reprocessar` (Ao reprocessar e fechar o modal, o botão deve mudar o título para `Reprocessando`), `Exportar`, `Capturar`, `Estornar` e `Gerar boleto`.
- Cheque se os botões estão recebendo seus títulos corretamente.
