### PR TITLE
cockpit: fix reprocess transactions payload

### DIFF
--- a/packages/cockpit/src/transactions/reprocess/cleanTransaction.js
+++ b/packages/cockpit/src/transactions/reprocess/cleanTransaction.js
@@ -2,11 +2,13 @@ import {
   __,
   always,
   applySpec,
+  complement,
   contains,
   curry,
   hasPath,
   ifElse,
   is,
+  isNil,
   lensProp,
   map,
   mapObjIndexed,
@@ -16,6 +18,7 @@ import {
   pathOr,
   pickBy,
   pipe,
+  prop,
   propEq,
   set,
 } from 'ramda'
@@ -49,13 +52,16 @@ const customerBuilder = ifElse(
   buildCustomerObject
 )
 
-const getCustomer = (transaction) => {
-  if (transaction.customer === null) {
-    return null
-  }
+const hasCustomer = pipe(
+  prop('customer'),
+  complement(isNil)
+)
 
-  return customerBuilder(transaction)
-}
+const getCustomer = ifElse(
+  hasCustomer,
+  customerBuilder,
+  always(null)
+)
 
 const ignoredProps = [
   'acquirer_id',

--- a/packages/cockpit/src/transactions/reprocess/cleanTransaction.js
+++ b/packages/cockpit/src/transactions/reprocess/cleanTransaction.js
@@ -1,8 +1,10 @@
 import {
   __,
   always,
+  applySpec,
   contains,
   curry,
+  hasPath,
   ifElse,
   is,
   lensProp,
@@ -12,10 +14,8 @@ import {
   omit,
   path,
   pathOr,
-  pick,
   pickBy,
   pipe,
-  prop,
   propEq,
   set,
 } from 'ramda'
@@ -33,14 +33,29 @@ const getCardId = ifElse(
 
 const getCustomerId = pathOr(null, ['customer', 'id'])
 
-const getCustomer = ifElse(
-  propEq('customer', null),
-  always(null),
-  pipe(
-    prop('customer'),
-    pick(['id'])
-  )
+const hasCustomerDocuments = hasPath(['customer', 'documents', 0])
+
+const buildCustomerObject = ({ address, phone, customer }) => ({
+  address,
+  phone,
+  ...customer
+})
+
+const customerBuilder = ifElse(
+  hasCustomerDocuments,
+  applySpec({
+    id: path(['customer', 'id'])
+  }),
+  buildCustomerObject
 )
+
+const getCustomer = (transaction) => {
+  if (transaction.customer === null) {
+    return null
+  }
+
+  return customerBuilder(transaction)
+}
 
 const ignoredProps = [
   'acquirer_id',

--- a/packages/cockpit/src/transactions/reprocess/cleanTransaction.test.js
+++ b/packages/cockpit/src/transactions/reprocess/cleanTransaction.test.js
@@ -1,11 +1,19 @@
 import {
   assoc,
+  assocPath,
   dissoc,
+  dissocPath,
   pipe,
 } from 'ramda'
 import cleanTransaction from './cleanTransaction'
 import fromRequest from './mocks/fromRequest.json'
 import toRequest from './mocks/toRequest.json'
+
+const buildCustomerObject = ({ address, phone, customer }) => ({
+  address,
+  phone,
+  ...customer,
+})
 
 describe('Reprocess', () => {
   it('should work', () => {
@@ -20,5 +28,22 @@ describe('Reprocess', () => {
     )(toRequest)
 
     expect(cleanTransaction(withoutCustomer)).toEqual(toRequestWithourCustomer)
+  })
+
+  it('should work when documents is empty', () => {
+    const withoutCustomer = assocPath(['customer', 'documents'], [], fromRequest)
+    const customerObject = buildCustomerObject(fromRequest)
+
+    const toRequestExpected = pipe(
+      assoc('customer', customerObject),
+      assocPath(['customer', 'documents'], []),
+      dissocPath(['customer', 'born_at']),
+      dissocPath(['customer', 'document_number']),
+      dissocPath(['customer', 'gender']),
+      dissocPath(['customer', 'phone', 'id']),
+      dissocPath(['customer', 'phone', 'object']),
+    )(toRequest)
+
+    expect(cleanTransaction(withoutCustomer)).toEqual(toRequestExpected)
   })
 })


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->
Após o redirecionamento dos usuários da dashboard para a pilot, notamos que algumas transações falhavam durante reprocessar. Investigando, chegamos a conclusão que isso só ocorria ao reprocessar transações com o antifraude ativo e originárias da api versão `2013-03-01`.

Isso ocorre devido a diferença na estrutura de requisição feita pela api `2013-03-01`, que exige que as informações do `customer` estejam preenchidas (não aceita apenas o customer.id).
## Checklist
- [x] Adicionar suporte a versão 2013-03-01 da api
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [x] Resolves https://github.com/pagarme/pilot/issues/1427
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Como testar?
<!-- Adicione algumas instruções de como os reviewers podem testar esse PR. -->
Reprocessar uma transação com antifraude ativo e com a versão da api 2013-03-01. O comportamento esperado é que a transação seja reprocessada com sucesso.
