### PR TITLE
Extrato - Corrige exibição de transferências bancárias

### DIFF
--- a/packages/cockpit/src/balance/mocks/operations/expected.json
+++ b/packages/cockpit/src/balance/mocks/operations/expected.json
@@ -19,9 +19,11 @@
       "actual": "2017-09-03T03:00:00.000Z",
       "original": null
     },
+    "status": "paid",
     "sourceId": null,
     "targetId": null,
     "transactionId": 1785151,
+    "transferId": null,
     "type": "refund"
   },
   {
@@ -48,9 +50,11 @@
       "actual": "2017-03-03T03:00:00.000Z",
       "original": null
     },
+    "status": "paid",
     "sourceId": null,
     "targetId": null,
     "transactionId": 1785141,
+    "transferId": null,
     "type": "credit_card"
   },
   {
@@ -77,9 +81,11 @@
       "actual": "2019-04-10T21:57:41.238Z",
       "original": null
     },
+    "status": "pending_transfer",
     "sourceId": null,
     "targetId": null,
     "transactionId": null,
+    "transferId": 204762,
     "type": "ted"
   },
   {
@@ -102,9 +108,11 @@
       "actual": "2019-04-17T21:50:54.308Z",
       "original": null
     },
+    "status": "pending_refund",
     "sourceId": null,
     "targetId": null,
     "transactionId": 6232675,
+    "transferId": null,
     "type": "boletoRefundFee"
   },
   {
@@ -127,9 +135,11 @@
       "actual": "2019-04-18T03:00:00.000Z",
       "original": null
     },
+    "status": "paid",
     "sourceId": null,
     "targetId": null,
     "transactionId": 6237321,
+    "transferId": null,
     "type": "boleto"
   },
   {
@@ -152,9 +162,11 @@
       "actual": "2019-04-18T03:00:00.000Z",
       "original": "2019-04-23T03:00:00.000Z"
     },
+    "status": "paid",
     "sourceId": null,
     "targetId": null,
     "transactionId": 6237281,
+    "transferId": null,
     "type": "refund"
   },
   {
@@ -177,9 +189,11 @@
       "actual": "2019-04-18T03:00:00.000Z",
       "original": null
     },
+    "status": "paid",
     "sourceId": null,
     "targetId": null,
     "transactionId": 6237273,
+    "transferId": null,
     "type": "chargeback"
   },
   {
@@ -202,9 +216,11 @@
       "actual": "2019-04-26T01:14:44.686Z",
       "original": null
     },
+    "status": "transferred",
     "sourceId": "re_abc",
     "targetId": "re_bcd",
     "transactionId": null,
+    "transferId": 208028,
     "type": "inter_recipient"
   },
   {
@@ -227,9 +243,11 @@
       "actual": "2019-04-26T01:14:44.686Z",
       "original": null
     },
+    "status": "transferred",
     "sourceId": "re_abc",
     "targetId": "re_bcd",
     "transactionId": null,
+    "transferId": 208028,
     "type": "inter_recipient"
   }
 ]

--- a/packages/cockpit/src/balance/mocks/payables/expected.json
+++ b/packages/cockpit/src/balance/mocks/payables/expected.json
@@ -17,6 +17,7 @@
     "sourceId": null,
     "targetId": null,
     "transactionId": 6318091,
+    "transferId": null,
     "type": "boleto"
   },
   {
@@ -42,6 +43,7 @@
     "sourceId": null,
     "targetId": null,
     "transactionId": 6318105,
+    "transferId": null,
     "type": "boleto"
   },
   {
@@ -62,6 +64,7 @@
     "sourceId": null,
     "targetId": null,
     "transactionId": 6318105,
+    "transferId": null,
     "type": "boleto"
   },
   {
@@ -87,6 +90,7 @@
     "sourceId": null,
     "targetId": null,
     "transactionId": 6293604,
+    "transferId": null,
     "type": "credit_card"
   }
 ]

--- a/packages/cockpit/src/balance/operations/buildRequest.js
+++ b/packages/cockpit/src/balance/operations/buildRequest.js
@@ -1,7 +1,6 @@
 import moment from 'moment-timezone'
 import {
   curry,
-  defaultTo,
   ifElse,
   propEq,
   uncurryN,
@@ -54,14 +53,11 @@ const buildPayablesRequest = curry((client, query) => {
     .then(formatPayablesRows)
 })
 
-const defaultToArray = defaultTo([])
-
 const buildOperationsRequest = curry((client, query) => {
   const operationsQuery = buildOperationsQuery(query)
 
   return client.balanceOperations
     .find(operationsQuery)
-    .then(defaultToArray)
     .then(formatOperationsRows)
 })
 

--- a/packages/cockpit/src/balance/operations/operations.js
+++ b/packages/cockpit/src/balance/operations/operations.js
@@ -3,6 +3,7 @@ import {
   always,
   both,
   cond,
+  either,
   ifElse,
   includes,
   juxt,
@@ -42,6 +43,11 @@ export const isTedTransfer = both(
   compareMovementTypeTo('ted')
 )
 
+export const isCreditTransfer = both(
+  propEq('type', 'transfer'),
+  compareMovementTypeTo('credito_em_conta')
+)
+
 export const zeroTransferAmount = always({
   amount: 0,
   type: 'payable',
@@ -49,6 +55,10 @@ export const zeroTransferAmount = always({
 
 export const tedTransferOutgoing = juxt([
   transformAndNegateMovementTypePropTo(['fee'], 'tedFee'),
+  transformMovementTypePropTo(['amount'], 'payable'),
+])
+
+export const creditTransferOutgoing = juxt([
   transformMovementTypePropTo(['amount'], 'payable'),
 ])
 
@@ -116,7 +126,7 @@ export const buildOutcoming = cond([
     refundOrChargeBackOutcoming,
   ],
   [
-    isTedTransfer,
+    either(isTedTransfer, isCreditTransfer),
     pipe(
       zeroTransferAmount,
       ofRamda
@@ -144,6 +154,10 @@ export const buildOutgoing = cond([
   [
     isTedTransfer,
     tedTransferOutgoing,
+  ],
+  [
+    isCreditTransfer,
+    creditTransferOutgoing,
   ],
   [
     isInterRecipientTransfer,

--- a/packages/cockpit/src/balance/operations/operations.test.js
+++ b/packages/cockpit/src/balance/operations/operations.test.js
@@ -12,6 +12,7 @@ import operations, {
   refundOrChargeBackOutcoming,
   refundOrChargeBackOutgoing,
   tedTransferOutgoing,
+  creditTransferOutgoing,
   zeroTransferAmount,
   creditOutcoming,
   creditOutgoing,
@@ -130,6 +131,24 @@ describe('Operations table data', () => {
       }]
 
       expect(outgoing).toEqual(expectedOutGoing)
+    })
+
+    it('should return a credit transfer outgoing array', () => {
+      const outgoing = creditTransferOutgoing({
+        ...operationMock,
+        type: 'transfer',
+        amount: -30000,
+        movement_object: {
+          type: 'credito_em_conta',
+        },
+      })
+
+      const expected = [{
+        amount: -30000,
+        type: 'payable',
+      }]
+
+      expect(outgoing).toEqual(expected)
     })
 
     it('should validate if is a transfer between recipients', () => {

--- a/packages/cockpit/src/balance/operations/shared.js
+++ b/packages/cockpit/src/balance/operations/shared.js
@@ -93,6 +93,12 @@ export const getTransactionId = ifElse(
   prop('transaction_id')
 )
 
+export const getTransferId = ifElse(
+  pathEq(['movement_object', 'object'], 'transfer'),
+  path(['movement_object', 'id']),
+  always(null)
+)
+
 export const getType = cond([
   [
     propEq('object', 'payable'),
@@ -112,6 +118,8 @@ export const getType = cond([
   [T, path(['movement_object', 'type'])],
 ])
 
+const getMovementObjectStatus = path(['movement_object', 'status'])
+
 export const formatRows = ({
   buildOutcoming,
   buildOutgoing,
@@ -128,9 +136,11 @@ export const formatRows = ({
       original: getOperationDate('original_payment_date'),
     },
     sourceId: getSourceId,
+    status: getMovementObjectStatus,
     targetId: getTargetId,
     type: getType,
     transactionId: getTransactionId,
+    transferId: getTransferId,
   })),
   sortWith([
     ascend(prop('id')),

--- a/packages/cockpit/src/balance/operations/shared.test.js
+++ b/packages/cockpit/src/balance/operations/shared.test.js
@@ -1,3 +1,4 @@
+import { mergeLeft } from 'ramda'
 
 import {
   isNegative,
@@ -7,6 +8,7 @@ import {
   getSourceId,
   getTargetId,
   getTransactionId,
+  getTransferId,
   getType,
 } from './shared'
 import operationMock from '../mocks/operation/received.json'
@@ -129,6 +131,19 @@ describe('Get transaction id', () => {
     const transacitonId = getTransactionId(payableMock)
 
     expect(transacitonId).toBe(6293604)
+  })
+})
+
+describe('Get transfer id', () => {
+  it('should get the transfer id correctly from an operation', () => {
+    const transferId = getTransferId(mergeLeft({
+      movement_object: {
+        object: 'transfer',
+        id: 123,
+      },
+    }, operationMock))
+
+    expect(transferId).toBe(123)
   })
 })
 

--- a/packages/cockpit/src/balance/total/buildRequest.js
+++ b/packages/cockpit/src/balance/total/buildRequest.js
@@ -2,7 +2,6 @@ import moment from 'moment-timezone'
 import {
   always,
   curry,
-  defaultTo,
   ifElse,
   isNil,
   propEq,
@@ -47,14 +46,11 @@ const buildPayablesRequest = curry((client, query) => {
     .then(formatPayablesRows)
 })
 
-const defaultToArray = defaultTo([])
-
 const buildOperationsRequest = curry((client, query) => {
   const operationsQuery = buildOperationsQuery(query)
 
   return client.balanceOperations
     .days(operationsQuery)
-    .then(defaultToArray)
     .then(formatOperationsRows)
 })
 

--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -378,6 +378,7 @@
       "details_title": "Detalhes do extrato",
       "empty_message": "Não foram encontrados lançamentos neste período",
       "export": "Exportar tudo",
+      "failed": "Estorno por falha na transferência",
       "from": "De",
       "gateway_service": "Serviços de gateway",
       "id": "Id da operação",
@@ -392,6 +393,7 @@
       "to": "Para",
       "transaction_id": "ID da transação",
       "transfer": "Saque",
+      "transfer_id": "Transferência",
       "transfer_fee": "TED",
       "withdraw": "Saque"
     },

--- a/packages/pilot/src/models/operationTypes.js
+++ b/packages/pilot/src/models/operationTypes.js
@@ -6,7 +6,9 @@ const types = {
   boletoRefundFee: 'models.operations.boleto_refund_fee',
   chargeback: 'models.operations.chargeback',
   credit_card: 'models.operations.credit_card',
+  credito_em_conta: 'models.operations.transfer',
   debit: 'models.operations.debit',
+  failed: 'models.operations.failed',
   from: 'models.operations.from',
   gateway: 'models.operations.gateway_service',
   installment: 'models.operations.installment',
@@ -17,6 +19,7 @@ const types = {
   tedFee: 'models.operations.transfer_fee',
   to: 'models.operations.to',
   transfer: 'models.operations.transfer',
+  transferId: 'models.operations.transfer_id',
   withdraw: 'models.operations.withdraw',
 }
 


### PR DESCRIPTION
## Contexto
Atualmente não temos previsto no cockpit as transferências para conta Bradesco. Este PR adiciona em nossa chamada `operations` as validações necessárias para que mostremos este tipo de transferência de `type: "credito_em_conta"`.

## Checklist
- [x] Transferências para conta Bradesco são exibidas normalmente, sem quebrar a funcionalidade da tela de Extrato

## Issues linkadas
- [x] Resolves #1491

## Screenshots

### Preview:

![image](https://user-images.githubusercontent.com/18339615/68797289-142fd800-0633-11ea-8f33-2cec9f9ba6b9.png)

## Como testar?
1. Crie um recebedor com conta bancária Bradesco:
```bash
curl -X POST \
  https://api.pagar.me/1/recipients \
  -H 'content-type: application/json' \
  -d '{
    "anticipatable_volume_percentage": "85", 
    "api_key": "<api_key>", 
    "automatic_anticipation_enabled": "true", 
    "transfer_day": "5", 
    "transfer_enabled": "true", 
    "transfer_interval": "weekly",
    "bank_account": {
	    "agencia": "0932", 
	    "agencia_dv": "5",
	    "bank_code": "237", 
	    "conta": "58054", 
	    "conta_dv": "1", 
	    "document_number": "26268738888", 
	    "legal_name": "API TEST BANK ACCOUNT"
	}
}'
```
2. Adicione nele uma transação de boleto:
```bash
curl -X POST \
  'https://api.pagar.me/1/transactions?api_key=<api key>' \
  -H 'Content-Type: application/json' \
  -d '{
	"amount": 7278,
	"payment_method": "boleto",
	"customer": {
		"name": "Customer Teste",
		"email": "customer@email.com",
		"document_number": "489.712.640-12",
		"address": {
			"zipcode": "06320100",
			"neighborhood": "Centro",
			"street_number": "17",
			"street": "R Atilio Tolaine"
		},
		"phone": {
			"number": "99999999",
			"ddd": "11"
		}
	},
	"split_rules": [
		{
			"amount": 7278,
			"recipient_id": "<id do recebedor>",
			"liable": "true",
			"charge_processing_fee": "true",
			"charge_remainder": "true"
		}
	]
}'
```
3. Simule o pagamento da transação de boleto:
```bash
curl -X PUT \
  'https://api.pagar.me/1/transactions/<id da transação>?api_key=<api key>' \
  -H 'content-type: application/json' \
  -d '{
    "status": "paid"
}'
```
4. Faça uma transferência para este recebedor:
```bash
curl -X POST \
  https://api.pagar.me/1/transfers \
  -H 'content-type: application/json' \
  -d '{
    "amount": "500", 
    "api_key": "<api key>", 
    "recipient_id": "<id do recebedor>"
}'
```

