### PR TITLE
Recebedores - Corrige storybook da tela de configurações

### DIFF
--- a/packages/pilot/src/containers/RecipientDetails/Config/HelpModal/index.js
+++ b/packages/pilot/src/containers/RecipientDetails/Config/HelpModal/index.js
@@ -64,8 +64,8 @@ const renderDX = t => (
   </Fragment>
 )
 
-const renderAllAnticipationModels = (capabilities, t) => {
-  if (capabilities) {
+const renderAllAnticipationModels = (canConfigureAnticipation, t) => {
+  if (canConfigureAnticipation) {
     return (
       <Fragment>
         {renderManualByVolume(t)}
@@ -78,6 +78,7 @@ const renderAllAnticipationModels = (capabilities, t) => {
       </Fragment>
     )
   }
+
   return (
     <Fragment>
       {renderManualByVolume(t)}
@@ -88,7 +89,7 @@ const renderAllAnticipationModels = (capabilities, t) => {
 }
 
 const HelpModal = ({
-  capabilities,
+  canConfigureAnticipation,
   isOpen,
   onExit,
   size,
@@ -111,7 +112,7 @@ const HelpModal = ({
         <small className={style.marginBottomforModal}>
           {t('pages.recipient_detail.subtitle_modal')}
         </small>
-        {renderAllAnticipationModels(capabilities, t)}
+        {renderAllAnticipationModels(canConfigureAnticipation, t)}
       </ModalContent>
       <ModalActions>
         <div className={style.justifyContent}>
@@ -126,9 +127,7 @@ const HelpModal = ({
 )
 
 HelpModal.propTypes = {
-  capabilities: PropTypes.shape({
-    canConfigureAnticipation: PropTypes.bool.isRequired,
-  }).isRequired,
+  canConfigureAnticipation: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onExit: PropTypes.func.isRequired,
   size: PropTypes.string.isRequired,

--- a/packages/pilot/src/containers/RecipientDetails/Config/index.js
+++ b/packages/pilot/src/containers/RecipientDetails/Config/index.js
@@ -309,7 +309,7 @@ class RecipientDetailConfig extends Component {
         </RecipientItem>
         <HelpModal
           anticipationModel={anticipation.anticipationModel}
-          capabilities={canConfigureAnticipation}
+          canConfigureAnticipation={canConfigureAnticipation}
           isOpen={openedModal}
           onExit={this.handleCloseHelpModal}
           size="huge"

--- a/packages/pilot/stories/containers/RecipientDetails/Config/index.js
+++ b/packages/pilot/stories/containers/RecipientDetails/Config/index.js
@@ -42,6 +42,7 @@ const mockBankAccount = {
   agency: '1111',
   agency_digit: '',
   bank: '001',
+  documentNumber: '99999999999',
   id: '1',
   name: 'Conta Bancária',
   number: '11111',
@@ -56,6 +57,9 @@ const RecipientDetailConfigExample = () => (
         accounts={mockAccounts}
         bankAccount={mockBankAccount}
         anticipation={mockAnticipation}
+        capabilities={{
+          canConfigureAnticipation: true,
+        }}
         transfer={mockTransfer}
         onSaveAnticipation={action('Saved Anticipation Data')}
         onSaveTransfer={action('Saved Transfer Data')}


### PR DESCRIPTION
## Contexto
A @miglsoares notou um erro em nosso percy à respeito da tela de configuração de recebedores. O que ocorreu foi que criamos uma nova prop em um dos componentes utilizado nesta tela, porém não passamos esta prop na story do componente, causando um erro no storybook. Este PR corrige isto.

## Checklist
- [x] Story `Containers|Page Containers|Recipient Configuration` é renderizada sem erros.

## Issues Linkadas
- [x] #1496

## Como testar?
1. Utilize o storybook e vá para a story `Containers|Page Containers|Recipient Configuration`
