### PR TITLE
Adiciona os valores de garantia de chargeback ao detalhe da transação

### DIFF
--- a/packages/cockpit/src/transactions/details/mocks/expectedResultAntifraud.json
+++ b/packages/cockpit/src/transactions/details/mocks/expectedResultAntifraud.json
@@ -87,6 +87,7 @@
       }
     ],
     "payment": {
+      "fraud_coverage_amount": 0,
       "cost_amount": 70,
       "installments": 1,
       "mdr_amount": 0,

--- a/packages/cockpit/src/transactions/details/mocks/expectedResultBoleto.json
+++ b/packages/cockpit/src/transactions/details/mocks/expectedResultBoleto.json
@@ -70,6 +70,7 @@
       }
     ],
     "payment": {
+      "fraud_coverage_amount": 0,
       "cost_amount": 0,
       "installments": 1,
       "mdr_amount": 0,

--- a/packages/cockpit/src/transactions/details/mocks/expectedResultFraudCovered.json
+++ b/packages/cockpit/src/transactions/details/mocks/expectedResultFraudCovered.json
@@ -306,7 +306,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.948Z",
             "net_amount": -29555175,
@@ -320,7 +320,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.948Z",
             "net_amount": -29555175,
@@ -334,7 +334,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.947Z",
             "net_amount": -29555175,
@@ -348,7 +348,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.947Z",
             "net_amount": -29555175,
@@ -362,7 +362,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.946Z",
             "net_amount": -29555175,
@@ -376,7 +376,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.946Z",
             "net_amount": -29555175,
@@ -390,7 +390,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.946Z",
             "net_amount": -29555175,
@@ -404,7 +404,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.945Z",
             "net_amount": -29555175,
@@ -418,7 +418,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.945Z",
             "net_amount": -29555175,
@@ -432,7 +432,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.945Z",
             "net_amount": -29555175,
@@ -446,7 +446,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.944Z",
             "net_amount": -29555175,
@@ -459,8 +459,8 @@
             "amount": -32839076,
             "costs": {
               "anticipation": 0,
-              "taxes": 0,
-              "mdr": -3283901
+              "mdr": -3283901,
+              "taxes": -3284001
             },
             "created_at": "2018-03-14T13:40:28.944Z",
             "net_amount": -29555175,

--- a/packages/cockpit/src/transactions/details/mocks/expectedResultFraudCovered.json
+++ b/packages/cockpit/src/transactions/details/mocks/expectedResultFraudCovered.json
@@ -459,8 +459,8 @@
             "amount": -32839076,
             "costs": {
               "anticipation": 0,
-              "mdr": -3283901,
-              "taxes": 0
+              "taxes": 0,
+              "mdr": -3283901
             },
             "created_at": "2018-03-14T13:40:28.944Z",
             "net_amount": -29555175,

--- a/packages/cockpit/src/transactions/details/mocks/expectedResultMock.json
+++ b/packages/cockpit/src/transactions/details/mocks/expectedResultMock.json
@@ -306,7 +306,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.948Z",
             "net_amount": -29555175,
@@ -320,7 +320,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.948Z",
             "net_amount": -29555175,
@@ -334,7 +334,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.947Z",
             "net_amount": -29555175,
@@ -348,7 +348,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.947Z",
             "net_amount": -29555175,
@@ -362,7 +362,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.946Z",
             "net_amount": -29555175,
@@ -376,7 +376,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.946Z",
             "net_amount": -29555175,
@@ -390,7 +390,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.946Z",
             "net_amount": -29555175,
@@ -404,7 +404,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.945Z",
             "net_amount": -29555175,
@@ -418,7 +418,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.945Z",
             "net_amount": -29555175,
@@ -432,7 +432,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.945Z",
             "net_amount": -29555175,
@@ -446,7 +446,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283909,
-              "taxes": 0
+              "taxes": -3284009
             },
             "created_at": "2018-03-14T13:40:28.944Z",
             "net_amount": -29555175,
@@ -460,7 +460,7 @@
             "costs": {
               "anticipation": 0,
               "mdr": -3283901,
-              "taxes": 0
+              "taxes": -3284001
             },
             "created_at": "2018-03-14T13:40:28.944Z",
             "net_amount": -29555175,

--- a/packages/cockpit/src/transactions/details/mocks/fromRequestsFraudCovered.json
+++ b/packages/cockpit/src/transactions/details/mocks/fromRequestsFraudCovered.json
@@ -1297,7 +1297,7 @@
     "date_created": "2018-03-14T13:40:28.465Z",
     "date_updated": "2018-03-14T16:11:52.057Z",
     "device": null,
-    "fraud_covered": false,
+    "fraud_covered": true,
     "id": 3082517,
     "installments": 12,
     "ip": "179.191.110.178",

--- a/packages/cockpit/src/transactions/details/result.js
+++ b/packages/cockpit/src/transactions/details/result.js
@@ -246,6 +246,7 @@ const mergeInstallment = (key, left, right) => {
     case 'amount':
     case 'net_amount':
     case 'mdr':
+    case 'taxes':
     case 'anticipation':
       return left + right
     default:
@@ -303,7 +304,6 @@ const mapRecipients = map(applySpec({
         anticipation: prop('anticipation_fee'),
         taxes: pipe(
           props(['fee', 'fraud_coverage_fee']),
-          values,
           sum
         ),
       },
@@ -457,11 +457,7 @@ const fraudCoverageAmountLens = lensPath(['transaction', 'payment', 'fraud_cover
 const sumAllRecipientsFraudCoverageFee = pipe(
   path(['transaction', 'payables']),
   pluck('fraud_coverage_fee'),
-  sum,
-  when(
-    isNil,
-    always(0)
-  )
+  sum
 )
 
 const netAmountLens = lensPath(['transaction', 'payment', 'net_amount'])

--- a/packages/cockpit/src/transactions/details/result.js
+++ b/packages/cockpit/src/transactions/details/result.js
@@ -8,6 +8,7 @@ import {
   both,
   complement,
   contains,
+  dissocPath,
   either,
   equals,
   find,
@@ -300,6 +301,11 @@ const mapRecipients = map(applySpec({
       costs: {
         mdr: prop('fee'),
         anticipation: prop('anticipation_fee'),
+        taxes: pipe(
+          props(['fee', 'fraud_coverage_fee']),
+          values,
+          sum
+        ),
       },
     })),
     groupBy(prop('number')),
@@ -426,6 +432,7 @@ const mapTransactionToResult = applySpec({
       pipe(prop('split_rules'), buildRecipients),
       pipe(prop('chargebackOperations'), buildReasonCode),
       pick(['capabilities']),
+      pick(['payables']),
     ]),
     mergeAll
   ),
@@ -445,6 +452,18 @@ const sumAllRecipientsMdrCost = pipe(
   sum
 )
 
+const fraudCoverageAmountLens = lensPath(['transaction', 'payment', 'fraud_coverage_amount'])
+
+const sumAllRecipientsFraudCoverageFee = pipe(
+  path(['transaction', 'payables']),
+  pluck('fraud_coverage_fee'),
+  sum,
+  when(
+    isNil,
+    always(0)
+  )
+)
+
 const netAmountLens = lensPath(['transaction', 'payment', 'net_amount'])
 
 const subtractMdrFromNetAmount = pipe(
@@ -459,5 +478,8 @@ export default pipe(
   juxt([sumAllRecipientsMdrCost, identity]),
   apply(set(mdrLens)),
   juxt([subtractMdrFromNetAmount, identity]),
-  apply(set(netAmountLens))
+  apply(set(netAmountLens)),
+  juxt([sumAllRecipientsFraudCoverageFee, identity]),
+  apply(set(fraudCoverageAmountLens)),
+  dissocPath(['transaction', 'payables'])
 )

--- a/packages/cockpit/src/transactions/details/result.test.js
+++ b/packages/cockpit/src/transactions/details/result.test.js
@@ -5,6 +5,8 @@ import fromRequestBoleto from './mocks/fromRequestsBoleto.json'
 import expectedResultBoleto from './mocks/expectedResultBoleto.json'
 import fromRequestAntifraud from './mocks/fromRequestsAntifraud.json'
 import expectedResultAntifraud from './mocks/expectedResultAntifraud.json'
+import fromRequestFraudCovered from './mocks/fromRequestsFraudCovered.json'
+import expectedResultFraudCovered from './mocks/expectedResultFraudCovered.json'
 
 describe('Transaction details', () => {
   it('should work when transaction, gatewayOperations, chargebackOperations, payables, company and status are returned', () => {
@@ -18,5 +20,10 @@ describe('Transaction details', () => {
   it('should build result when pending manual review', () => {
     expect(buildResult(fromRequestAntifraud))
       .toBeJsonEqual(expectedResultAntifraud)
+  })
+
+  it('should build result when fraud covered', () => {
+    expect(buildResult(fromRequestFraudCovered))
+      .toBeJsonEqual(expectedResultFraudCovered)
   })
 })

--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -505,6 +505,7 @@
       "anticipation": "SERVIÇO DE ANTECIPAÇÃO",
       "chargeback_refund": "ESTORNO OU CHARGEBACK",
       "mdr": "MDR",
+      "mdr_with_fraud_coverage": "MDR + COBERTURA DE FRAUDES",
       "net_amount": "VALOR LÍQUIDO",
       "number": "PARCELA",
       "payment_date": "DATA",
@@ -546,6 +547,7 @@
     },
     "payment": {
       "mdr": "MDR: R$ {{value}}",
+      "mdr_with_fraud_coverage": "MDR + Cobertura de Fraudes: R$ {{value}}",
       "cost": "Custo de processamento: R$ {{value}}*",
       "refund": "Valor estornado: R$ {{value}}"
     },

--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -510,7 +510,8 @@
       "number": "PARCELA",
       "payment_date": "DATA",
       "status": "STATUS DA PARCELA",
-      "total": "TOTAL BRUTO"
+      "total": "TOTAL BRUTO",
+      "tax": "TAXAS"
     },
     "operations": {
       "anticipation": "Antecipação",

--- a/packages/pilot/src/components/RecipientSection/installmentTableColumns.js
+++ b/packages/pilot/src/components/RecipientSection/installmentTableColumns.js
@@ -133,13 +133,13 @@ const columns = [
     title: 'models.installment.total',
   },
   {
-    accessor: ['costs', 'mdr'],
+    accessor: ['costs', 'taxes'],
     aggregationRenderer: currencyFormatter,
     aggregator: sumParameters,
     align: 'end',
     orderable: false,
-    renderer: ({ costs }) => currencyFormatter(costs.mdr),
-    title: 'models.installment.mdr',
+    renderer: ({ costs }) => currencyFormatter(costs.taxes),
+    title: 'models.installment.tax',
   },
   {
     accessor: ['costs', 'anticipation'],

--- a/packages/pilot/src/containers/TransactionDetails/index.js
+++ b/packages/pilot/src/containers/TransactionDetails/index.js
@@ -573,6 +573,7 @@ class TransactionDetails extends Component {
                     getOutAmount([
                       payment.refund_amount,
                       payment.mdr_amount,
+                      payment.fraud_coverage_amount,
                     ])
                   }
                   amountSize="large"
@@ -600,7 +601,11 @@ class TransactionDetails extends Component {
               <CardContent className={style.content}>
                 <TotalDisplay
                   align="start"
-                  amount={(payment.net_amount + payment.cost_amount)}
+                  amount={(
+                    payment.net_amount
+                    + payment.cost_amount
+                    - payment.fraud_coverage_amount
+                  )}
                   amountSize="large"
                   color="#4d4f62"
                   subtitle={(

--- a/packages/pilot/src/pages/Transactions/Details/Details.js
+++ b/packages/pilot/src/pages/Transactions/Details/Details.js
@@ -626,9 +626,17 @@ class TransactionDetails extends Component {
       cost: t('models.payment.cost', {
         value: currencyFormatter(payment.cost_amount || 0),
       }),
-      mdr: t('models.payment.mdr', {
-        value: currencyFormatter(payment.mdr_amount || 0),
-      }),
+      mdr: payment.fraud_coverage_amount > 0
+        ? t('models.payment.mdr_with_fraud_coverage', {
+          value: currencyFormatter(
+            payment.mdr_amount + payment.fraud_coverage_amount || 0
+          ),
+        })
+        : t('models.payment.mdr', {
+          value: currencyFormatter(
+            payment.mdr_amount || 0
+          ),
+        }),
       net_amount: t('pages.transaction.net_amount'),
       out_amount: t('pages.transaction.out_amount'),
       paid_amount: t('pages.transaction.paid_amount'),

--- a/packages/pilot/src/pages/Transactions/Details/Details.js
+++ b/packages/pilot/src/pages/Transactions/Details/Details.js
@@ -629,7 +629,7 @@ class TransactionDetails extends Component {
       mdr: payment.fraud_coverage_amount > 0
         ? t('models.payment.mdr_with_fraud_coverage', {
           value: currencyFormatter(
-            payment.mdr_amount + payment.fraud_coverage_amount || 0
+            payment.mdr_amount + payment.fraud_coverage_amount
           ),
         })
         : t('models.payment.mdr', {

--- a/packages/pilot/stories/pages/TransactionDetails/index.js
+++ b/packages/pilot/stories/pages/TransactionDetails/index.js
@@ -105,10 +105,16 @@ const totalDisplayLabels = {
   captured_at: `Capturado em ${
     moment(transactionMock.captured_at).format('L')
   }`,
-  cost: 'Custo de processamento: R$ 1,20',
-  mdr: `MDR: R$ ${
-    currencyFormatter(transactionMock.payment.cost_amount || 0)
-  }`,
+  mdr: transactionMock.payment.fraud_coverage_amount > 0
+    ? `MDR + Cobertura de Fraudes: R$ ${
+      currencyFormatter(
+        transactionMock.payment.fraud_coverage_amount
+        + transactionMock.payment.cost_amount || 0
+      )
+    }`
+    : `MDR: R$ ${
+      currencyFormatter(transactionMock.payment.cost_amount || 0)
+    }`,
   net_amount: 'VALOR LÍQUIDO',
   out_amount: 'TOTAL DE SAÍDAS',
   paid_amount: 'VALOR CAPTURADO',

--- a/packages/pilot/stories/pages/TransactionDetails/index.js
+++ b/packages/pilot/stories/pages/TransactionDetails/index.js
@@ -109,7 +109,7 @@ const totalDisplayLabels = {
     ? `MDR + Cobertura de Fraudes: R$ ${
       currencyFormatter(
         transactionMock.payment.fraud_coverage_amount
-        + transactionMock.payment.cost_amount || 0
+        + transactionMock.payment.cost_amount
       )
     }`
     : `MDR: R$ ${


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->
Esse PR adiciona o valor da garantia de chargeback no "Total de Saídas", "Valor Líquido", "Taxas" e total de taxas.

Adiciona aos mocks o `fraud_coverage_fee`, para que seja possível calcular o `fraud_coverage_amount` (soma de todos os `fraud_coverage_fee`).

Adiciona ao `costs` a propriedade `taxes`, que é a soma do `mdr` e `fraud_coverage_amount`.

## Checklist
- [x] Adiciona o valor total de garantia de chargeback no "Total de Saídas"
- [x] Subtrai o valor total de garantia de chargeback no "Valor Líquido"
- [x] Adiciona o valor da garantia de chargeback a listagem de parcelas
- [x] Adiciona o valor total da garantia de chargeback ao total das parcelas
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
https://github.com/pagarme/protection/issues/740

## Screenshots
![Screenshot_20191223_223148](https://user-images.githubusercontent.com/18751842/71387739-1858f900-25d4-11ea-90ef-127ca616c6e2.png)
<!-- Adicione algumas imagens para haver um preview da sua tarefa, para ajudar desenvolvedores e designers a entender facilmente no que você está trabalhando. -->

## Como testar?
1) Ter uma company com garantia ativa.
2) Criar uma transação paga com cartão de crédito
