### PR TITLE
chore: send company type to appcues

### DIFF
--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -150,6 +150,7 @@ const companyEpic = (action$, state$) => action$.pipe(
       id,
       name,
       status,
+      type,
     } = payload
 
     const {
@@ -165,6 +166,7 @@ const companyEpic = (action$, state$) => action$.pipe(
       name,
       dateCreated,
       status,
+      type,
       userId
     )
 

--- a/packages/pilot/src/vendor/appcues.js
+++ b/packages/pilot/src/vendor/appcues.js
@@ -40,6 +40,7 @@ export const identify = (
  * @param {string} companyName company name
  * @param {string} companyDateCreated company created date
  * @param {string} companyStatus company status
+ * @param {string} companyType company type
  * @param {number} userId user id
  *
  */
@@ -48,6 +49,7 @@ export const setCompany = (
   companyName,
   companyDateCreated,
   companyStatus,
+  companyType,
   userId
 ) => {
   if (hasProperty(window.Appcues)) {
@@ -58,6 +60,7 @@ export const setCompany = (
         companyId,
         companyName,
         companyStatus,
+        companyType,
       }
     )
   }

--- a/packages/pilot/src/vendor/setCompany.js
+++ b/packages/pilot/src/vendor/setCompany.js
@@ -10,6 +10,7 @@ import { setCompany as fullStorySetCompany } from './fullStory'
  * @param {string} companyName company name
  * @param {string} companyDateCreated company created date
  * @param {string} companyStatus company status
+ * @param {string} companyType company type
  * @param {number} userId user id
  *
  */


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto

Adiciona a propriedade `company.type` na função `setCompany` que envia dados para o AppCues. 

Precisamos desta informação no AppCues para conseguir filtrar quais mensagens devem aparecer, dependendo do tipo da company.
<!-- Qual problema está tentando resolver? -->

## Checklist
- [ ] Altera o `packages/pilot/src/pages/Account/actions/epic.js` para também enviar o companyType na função `setCompanies`
- [ ] Altera a função `setCompany` no arquivo `packages/pilot/src/vendor/appcues.js` para também enviar o companyType.
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [ ] Resolves https://github.com/pagarme/credenciamento/issues/392
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Screenshots

Não houve alterações visuais :heavy_check_mark: 
<!-- Adicione algumas imagens para haver um preview da sua tarefa, para ajudar desenvolvedores e designers a entender facilmente no que você está trabalhando. -->

### Layout:

Não houve alterações visuais :heavy_check_mark: 
<!-- Insira o layout do Zeplin desta tarefa. -->

### Preview:

Não houve alterações visuais :heavy_check_mark: 
<!-- Adicione quando não há um snapshot no Percy. -->

## Notas de deploy

Não há notas de deploy :heavy_check_mark: 
<!-- Notas de deploy do desenvolvimento da aplicação. Devem ser novas dependências, scripts, etc. -->

## Como testar?
<!-- Adicione algumas instruções de como os reviewers podem testar esse PR. -->

* Verificar que o `companyType` está sendo enviado na requisição para o AppCues.
