### PR TITLE
Add fullstory block

### DIFF
--- a/packages/pilot/src/components/ApiKey/index.js
+++ b/packages/pilot/src/components/ApiKey/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classnames from 'classnames'
 import { Button } from 'former-kit'
 import IconCopy from 'emblematic-icons/svg/Copy24.svg'
 
@@ -23,7 +24,7 @@ const ApiKey = ({
         {copyLabel}
       </Button>
     </div>
-    <div className={style.content}>
+    <div className={classnames(style.content, 'fs-block')}>
       {apiKey}
     </div>
   </div>

--- a/packages/pilot/src/vendor/fullStory.js
+++ b/packages/pilot/src/vendor/fullStory.js
@@ -25,7 +25,7 @@ export const identify = (
       {
         email_str: email,
         environment_str: environment,
-        userDateCreated_str: userDateCreated,
+        userDateCreated_date: new Date(userDateCreated),
         userName_str: userName,
         userPermission_str: userPermission,
       }
@@ -45,7 +45,7 @@ export const identify = (
 export const setCompany = (id, name, dateCreated, status) => {
   if (hasProperty(window.FS)) {
     window.FS.setUserVars({
-      companyDateCreated_str: dateCreated,
+      companyDateCreated_date: new Date(dateCreated),
       companyId_str: id,
       companyName_str: name,
       companyStatus_str: status,


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
esste pr:
- adiciona a classe `fs-block`na exibição de api-keys
- altera o envio das datas de criação do usuário e company para o tipo `date` no fullstory

## Issues linkadas
- https://github.com/pagarme/greenphoenix/issues/169

## Como testar?
- baixar a branch `add/fullstory-block`
- executar a pilot
- navegar para tela de configuração
- verificar se os elementos pai da exibição das api keys contem a classe `fs-block`