### PR TITLE
Links de pagamento - Adiciona componente header

### DIFF
--- a/packages/pilot/src/containers/PaymentLinks/Header/index.js
+++ b/packages/pilot/src/containers/PaymentLinks/Header/index.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  Button,
+  Card,
+  CardContent,
+  Grid,
+  Row,
+  Col,
+} from 'former-kit'
+
+import style from './style.css'
+
+const PaymentLinkHeader = ({
+  onAddPaymentLink,
+  t,
+}) => (
+  <Card>
+    <CardContent>
+      <Grid>
+        <Row className={style.verticalAlign}>
+          <Col
+            desk={3}
+            palm={12}
+            tablet={12}
+            tv={3}
+          >
+            <h2 className={style.title}>
+              {t('pages.payment_links.receive_payments')}
+            </h2>
+            <span className={style.subtitle}>
+              {t('pages.payment_links.share_payment_links')}
+            </span>
+          </Col>
+          <Col
+            align="end"
+            desk={9}
+            palm={12}
+            tablet={12}
+            tv={9}
+          >
+            <div className={style.createLink}>
+              <Button onClick={onAddPaymentLink}>
+                {t('pages.payment_links.create_payment_link')}
+              </Button>
+            </div>
+          </Col>
+        </Row>
+      </Grid>
+    </CardContent>
+  </Card>
+)
+
+PaymentLinkHeader.propTypes = {
+  onAddPaymentLink: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired,
+}
+
+export default PaymentLinkHeader

--- a/packages/pilot/src/containers/PaymentLinks/Header/style.css
+++ b/packages/pilot/src/containers/PaymentLinks/Header/style.css
@@ -1,0 +1,21 @@
+@import "former-kit-skin-pagarme/dist/styles/typography.css";
+@import "former-kit-skin-pagarme/dist/styles/colors.css";
+@import "former-kit-skin-pagarme/dist/styles/spacing.css";
+
+.verticalAlign {
+  align-items: center;
+}
+
+.title,
+.subtitle {
+  color: var(--color-light-noir-100);
+}
+
+.title {
+  margin-top: 0;
+  margin-bottom: var(--spacing-small);
+}
+
+.subtitle {
+  font-size: 14px;
+}

--- a/packages/pilot/stories/components/PaymentLinkHeader/index.js
+++ b/packages/pilot/stories/components/PaymentLinkHeader/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { identity } from 'ramda'
+import { action } from '@storybook/addon-actions'
+
+import Section from '../../Section'
+import PaymentLinkHeader from '../../../src/containers/PaymentLinks/Header'
+
+const PaymentLinkHeaderExample = () => (
+  <Section>
+    <PaymentLinkHeader
+      t={identity}
+      onAddPaymentLink={action('onAddPaymentLink')}
+    />
+  </Section>
+)
+
+export default PaymentLinkHeaderExample

--- a/packages/pilot/stories/components/index.js
+++ b/packages/pilot/stories/components/index.js
@@ -42,6 +42,7 @@ import PasswordInput from './PasswordInput'
 import ConfirmModal from './ConfirmModal'
 import WithLoader from './withLoader'
 import WithSpinner from './withSpinner'
+import PaymentLinkHeader from './PaymentLinkHeader'
 
 storiesOf('Components|Custom components', module)
   .addDecorator(withA11y)
@@ -83,6 +84,7 @@ storiesOf('Components|Custom components', module)
   .add('MetricList', () => <MetricList />)
   .add('MetricChart', () => <MetricChart />)
   .add('Confirm Modal', () => <ConfirmModal />)
+  .add('PaymentLinkHeader', () => <PaymentLinkHeader />)
 
 storiesOf('Components|High Order Components', module)
   .add('with loader', () => <WithLoader />)


### PR DESCRIPTION
## Contexto
Este PR adiciona o componente Header que será utilizado na lista de links de pagamento

## Checklist
- [x] Componente recebe a função de translation
- [x] Componente recebe uma função para o evento de click no botão

## Issues linkadas
- [x] Resolves #1513

## Screenshots

### Layout:
![image](https://user-images.githubusercontent.com/18339615/73022012-79f4c900-3e07-11ea-81ea-4a0fa61c7968.png)

### Preview:
![image](https://user-images.githubusercontent.com/18339615/73022005-76614200-3e07-11ea-88de-ac35563f1c49.png)

## Como testar?
1. Rode o storybook com `cd packages/pilot && yarn storybook`
2. Acesse a story Custom Components -> PaymentLinkHeader