### PR TITLE
Adicionar FakeLoader

### DIFF
--- a/packages/pilot/package.json
+++ b/packages/pilot/package.json
@@ -10,7 +10,7 @@
     "cpf_cnpj": "0.2.0",
     "emblematic-icons": "0.7.1",
     "former-kit": "1.7.4",
-    "former-kit-skin-pagarme": "1.5.4",
+    "former-kit-skin-pagarme": "1.6.0",
     "i18next": "13.1.2",
     "i18next-browser-languagedetector": "2.2.4",
     "i18next-xhr-backend": "1.5.1",

--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -1666,6 +1666,13 @@
       "start": "Início",
       "today": "Hoje"
     },
+    "fake_loader": {
+      "title": "Preparando o seu painel",
+      "steps_info": "Passo {{currentStep}} de {{finalStep}}:",
+      "step_1": "Gerando a sua chave de API",
+      "step_2": "Organizando as documentações",
+      "step_3": "Customizando a sua interface"
+    },
     "filter": {
       "apply": "Filtrar",
       "reset": "Limpar filtros",

--- a/packages/pilot/src/components/FakeLoader/index.js
+++ b/packages/pilot/src/components/FakeLoader/index.js
@@ -1,0 +1,53 @@
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { Flexbox } from 'former-kit'
+import Spinner from '../Spinner'
+import styles from './styles.css'
+
+const FakeLoader = ({ runAfterLoader, t }) => {
+  const [currentStep, setCurrentStep] = useState(1)
+  const finalStep = 3
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (currentStep >= finalStep) {
+        return runAfterLoader()
+      }
+
+      return setCurrentStep(currentStep + 1)
+    }, 1500)
+
+    return () => clearInterval(interval)
+  })
+
+  return (
+    <Flexbox
+      alignItems="center"
+      className={styles.fakeLoader}
+      direction="column"
+      justifyContent="center"
+    >
+      <Spinner />
+      <h1>{t('components.fake_loader.title')}</h1>
+      <div>
+        <span>
+          {t('components.fake_loader.steps_info', { currentStep, finalStep })}
+        </span>
+        <span>
+          {t(`components.fake_loader.step_${currentStep}`)}
+        </span>
+      </div>
+    </Flexbox>
+  )
+}
+
+FakeLoader.propTypes = {
+  runAfterLoader: PropTypes.func,
+  t: PropTypes.func.isRequired,
+}
+
+FakeLoader.defaultProps = {
+  runAfterLoader: () => {},
+}
+
+export default FakeLoader

--- a/packages/pilot/src/components/FakeLoader/styles.css
+++ b/packages/pilot/src/components/FakeLoader/styles.css
@@ -1,0 +1,35 @@
+@import "former-kit-skin-pagarme/dist/styles/colors/light.css";
+@import "former-kit-skin-pagarme/dist/styles/typography.css";
+@import "former-kit-skin-pagarme/dist/styles/webfonts/roboto/index.css";
+
+.fakeLoader {
+  background-color: var(--color-squanchy-gray-20);
+  height: 100vh;
+  width: 100vw;
+
+  & svg {
+    height: 110px;
+    width: 110px;
+  }
+
+  & h1,
+  & span {
+    font-family: "Roboto", sans-serif;
+  }
+
+  & h1 {
+    color: var(--color-birdperson-gray-600);
+    font-weight: bold;
+    margin-bottom: 5px;
+  }
+
+  & span {
+    color: var(--color-squanchy-gray-300);
+    font-size: var(--body-font-size);
+    margin-top: 10px;
+  }
+
+  & span:first-of-type {
+    margin-right: 4.5px;
+  }
+}

--- a/packages/pilot/src/components/Spinner/index.js
+++ b/packages/pilot/src/components/Spinner/index.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import styles from './styles.css'
+
+const Spinner = () => (
+  <div className={styles.spinner}>
+    <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+      <circle
+        cx="50"
+        cy="50"
+        fill="none"
+        r="46.5"
+        stroke="#6045af"
+        strokeDasharray="150 30"
+        strokeLinecap="round"
+        strokeWidth="5.5"
+      />
+      <circle
+        cx="50"
+        cy="50"
+        fill="none"
+        r="35"
+        stroke="#65a300"
+        strokeDasharray="50 200"
+        strokeLinecap="round"
+        strokeWidth="5.5"
+      />
+    </svg>
+  </div>
+)
+
+export default Spinner

--- a/packages/pilot/src/components/Spinner/styles.css
+++ b/packages/pilot/src/components/Spinner/styles.css
@@ -1,0 +1,19 @@
+@keyframes rotateSpinner {
+
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner svg > circle {
+  transform-origin: center;
+  animation: rotateSpinner 1.5s linear infinite;
+}
+
+.spinner svg > circle:last-of-type {
+  animation: rotateSpinner 0.8s linear infinite;
+}

--- a/packages/pilot/stories/components/FakeLoader/index.js
+++ b/packages/pilot/stories/components/FakeLoader/index.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import {
+  always,
+  cond,
+  equals,
+} from 'ramda'
+
+import FakeLoader from '../../../src/components/FakeLoader'
+
+const translations = cond([
+  [equals('components.fake_loader.title'), always('Preparando o seu painel')],
+  [equals('components.fake_loader.steps_info'), (...[, { currentStep, finalStep }]) => `Passo ${currentStep} de ${finalStep}:`],
+  [equals('components.fake_loader.step_1'), always('Gerando a sua chave de API')],
+  [equals('components.fake_loader.step_2'), always('Organizando as documentações')],
+  [equals('components.fake_loader.step_3'), always('Customizando a sua interface')],
+])
+
+const FakeLoaderExample = () => (
+  <FakeLoader t={translations} />
+)
+
+export default FakeLoaderExample

--- a/packages/pilot/stories/components/index.js
+++ b/packages/pilot/stories/components/index.js
@@ -15,6 +15,7 @@ import DescriptionAlert from './DescriptionAlert'
 import DetailsHead from './DetailsHead'
 import EventList from './EventList'
 import ExportData from './ExportData'
+import FakeLoader from './FakeLoader'
 import PaymentCards from './PaymentCards'
 import Property from './Property'
 import MetricIndicator from './MetricIndicator'
@@ -56,6 +57,7 @@ storiesOf('Components|Custom components', module)
   .add('Transaction details card', () => <TransactionDetailsCard />)
   .add('Event list', () => <EventList />)
   .add('Export Data', () => <ExportData />)
+  .add('Fake Loader', () => <FakeLoader />)
   .add('DataDisplay', () => <DataDisplay />)
   .add('Description Alert', () => <DescriptionAlert />)
   .add('Reprocess details', () => <ReprocessDetails />)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7028,6 +7028,14 @@ former-kit-skin-pagarme@1.5.4:
     emblematic-icons "0.7.1"
     react-dates "18.4.1"
 
+former-kit-skin-pagarme@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-1.6.0.tgz#34f1ded5523f6ea5896798589e8bf8c942b70405"
+  integrity sha512-2OWb+Y7BofM4Ut2/4lMlX6cm6lxFwvRNciFj4zGzN1R+1tiRvab3poA+krQnHNqlUSxIYGJfgaQcX5epDTU0RA==
+  dependencies:
+    emblematic-icons "0.7.1"
+    react-dates "18.4.1"
+
 former-kit@1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/former-kit/-/former-kit-1.7.4.tgz#747b914fce4ba96ab90c5b05c8b8e50fa98adf85"


### PR DESCRIPTION
## Contexto

Conforme detalhado na issue https://github.com/pagarme/pilot/issues/1579, estamos partindo para a segunda etapa do fluxo de Onboarding, etapa na qual serão mostradas algumas perguntas com a expectativa que nosso cliente as respondam e nos forneçam insumos para melhorarmos o seu processo de onboarding na pagar.me.

Neste PR está adicionado o componente `FakeLoader`. A função deste componente é simular a construção de uma dashboard após o usuário responder todas as perguntas. A ideia é que com o _loader_, ocorra um alinhamento entre a expectativa do usuário com a dashboard.

O componente `FakeLoader` é composto de um Spinner e três steps. 
Cada step irá mostrar uma mensagem (sendo que as imagens podem ser visualizadas no Figma), sendo que cada step deve demorar 1.5 segundos.
Após os três steps, o componente deve executar uma função (no futuro essa função irá redirecionar o usuário para `/home`).

## Checklist
- [x] Adiciona o componente `Spinner`
- [x] Adiciona o componente `FakeLoader`

## Issues linkadas
- [x] Related to https://github.com/pagarme/pilot/issues/1579
- [x] Resolves https://github.com/pagarme/credenciamento/issues/467

## Screenshots
<!-- Adicione algumas imagens para haver um preview da sua tarefa, para ajudar desenvolvedores e designers a entender facilmente no que você está trabalhando. -->

### Layout:
[Link do Figma](https://www.figma.com/file/kVlmDxHiI7FQcOARicddD2/Onboarding)

![image](https://user-images.githubusercontent.com/13531067/75711380-159a1480-5ca5-11ea-9c8f-98f133b4fe6a.png)

### Preview:

![layout](https://user-images.githubusercontent.com/13531067/75711434-2ba7d500-5ca5-11ea-9dbf-d5870c51f1b8.png)

## Como testar?

Para testar, é necessário linkar a branch `master` do `former-kit-skin-pagarme` para ter as cores atualizadas.
Depois rode o storybook e verifique se o comportamento do componente está semelhante ao layout da página :)
