### PR TITLE
Refactor alreadyTransacted flag

### DIFF
--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -1,6 +1,8 @@
 import pagarme from 'pagarme'
 import {
+  complement,
   identity,
+  isEmpty,
   pathOr,
   propEq,
 } from 'ramda'
@@ -40,6 +42,8 @@ const isSelfRegister = propEq('type', 'self_register')
 const isPendingRiskAnalysis = propEq('status', 'pending_risk_analysis')
 
 const getRecipientId = pathOr(null, ['account', 'company', 'default_recipient_id', env])
+
+const isNotEmpty = complement(isEmpty)
 
 const errorHandler = (error) => {
   store.dispatch(receiveError(error))
@@ -143,9 +147,9 @@ const companyEpic = (action$, state$) => action$.pipe(
 
     return client
       .transactions
-      .search({ count: 1 })
-      .then(({ result: { total: { count } } }) => {
-        const alreadyTransacted = count > 0
+      .all({ count: 1 })
+      .then((transactions) => {
+        const alreadyTransacted = isNotEmpty(transactions)
         return { ...action, alreadyTransacted }
       })
       .catch(errorPayload => ({


### PR DESCRIPTION
## Contexto

Notou-se que para alguns clientes que já transacionaram na pilot e foram criados a mais de 30 dias, o emptyState estava sendo exibido. A issue https://github.com/pagarme/credenciamento/issues/477 fornece mais detalhes sobre o ocorrido.

Isto está fugindo a seguinte regra `A página do EmptyState padrão deve ser mostrado para clientes que foram cadastrados a menos de um mês ou que ainda não transacionaram.`, postada na issue https://github.com/pagarme/pilot/issues/1570.

Ao realizarmos a investigação, ficou um pouco nebuloso sobre qual é a raiz do problema. Isto porque a rota `/search` da API não possui logs da resposta, o que acaba dificultando no entendimento do problema. Entretanto, pelo que debuguei, está é a única fonte que pode estar causando este comportamento, visto que por padrão, o emptyState não seria exibido.

Desta forma, este PR altera a API utilizada para consultar se o usuário já transacionou ou não. Ao invés de utilizarmos a rota `/search`, agora iremos utilizar a rota `/transactions?count=1`. Como está rota produz logs, irá ficar mais facil de debugar o que está acontecendo caso haja algum problema.

Se a rota `transactions?count=1` retornar uma lista vazia significa que o usuário ainda não transacionou, e, caso retorna uma lista com um item significa que o usuário transacionou. 

## Checklist
- [x] Altera a API utilizada para consultar se o usuário já transacionou (de `/search` para `/transactions?count=1`).

## Issues linkadas
- [x] Closes https://github.com/pagarme/credenciamento/issues/477
