### PR TITLE
onboarding: update others state on new question

### DIFF
--- a/packages/pilot/src/containers/Onboarding/index.js
+++ b/packages/pilot/src/containers/Onboarding/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Button } from 'former-kit'
 import CardOptions from './CardOptions'
@@ -23,6 +23,8 @@ const OnboardingContainer = ({
   userName,
 }) => {
   const [others, setOthers] = useState({})
+
+  useEffect(() => setOthers({}), [question])
 
   const handleOthers = (value, isChecked) => setOthers({
     ...others,


### PR DESCRIPTION
## Contexto

Conforme identificado pelo @vagnervst [neste comment](https://github.com/pagarme/pilot/pull/1592#issuecomment-608088241), não está sendo resetado o estado `others` quando uma nova pergunta chega.

Isto acaba causando com que todas as perguntas enviem o mesmo estado, o que no caso é o desejado.

Desta forma, este PR adiciona um `useEffect` para reiniciar o estado de `others` toda vez que houver uma nova pergunta.

## Checklist
- [ ] Reseta o estado de `others` toda vez que houver uma nova pergunta.

## Issues linkadas
- [ ] Related to https://github.com/pagarme/pilot/issues/1579