### PR TITLE
Release v0.24.1

### DIFF
--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -3,6 +3,7 @@ import {
   complement,
   identity,
   isEmpty,
+  pathEq,
   pathOr,
   propEq,
 } from 'ramda'

--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -4,6 +4,7 @@ import {
   identity,
   isEmpty,
   pathEq,
+  isEmpty,
   pathOr,
   propEq,
 } from 'ramda'

--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -4,7 +4,6 @@ import {
   identity,
   isEmpty,
   pathEq,
-  isEmpty,
   pathOr,
   propEq,
 } from 'ramda'

--- a/packages/pilot/src/pages/Withdraw/index.js
+++ b/packages/pilot/src/pages/Withdraw/index.js
@@ -7,8 +7,8 @@ import {
   always,
   compose,
   cond,
-  contains,
   equals,
+  includes,
   isNil,
   path,
   pathOr,
@@ -153,7 +153,7 @@ class Withdraw extends Component {
       // eslint-disable-next-line camelcase
       const { pricing: { transfers: { credito_em_conta, ted } } } = this.props
 
-      if (contains(partnersBankCodes, bankCode)) {
+      if (includes(bankCode, partnersBankCodes)) {
         return -credito_em_conta // eslint-disable-line camelcase
       }
 


### PR DESCRIPTION
## Contexto
## Checklist
- [ ] [Login - Adiciona verificação por capability](https://github.com/pagarme/pilot/pull/1595)
- [ ] Custo de saque incorreto para companies com crédito em conta #1597

## Issues linkadas
- [ ] Resolves https://github.com/pagarme/tecnologia-vendas/issues/837
- [ ] Custo de saque incorreto para companies com crédito em conta #1597

## Como testar?
### login com allow_dashboard_login false
- Tentar logar com uma company cuja capability `allow_dashboard_login` como `false`. Não deverá ser permitido.
### cobraça de saque com conta bradesco
1. Crie uma conta bancária de código `237`:

    ```bash
    curl -L -X POST 'https://api.pagar.me/1/bank_accounts' \
    -H 'content-type: application/json' \
    --data-raw '{
        "agencia": "0932", 
        "agencia_dv": "5", 
        "api_key": "<chave de api>", 
        "bank_code": "237", 
        "conta": "58054", 
        "conta_dv": "1", 
        "document_number": "00000000000000", 
        "legal_name": "API TEST BANK ACCOUNT"
    }'
    ```
2. Altere o seu recebedor principal para utilizar a conta bancária criada:

    ```bash
    curl -L -X PUT 'https://api.pagar.me/1/recipients/<id do recebedor default>' \
    -H 'content-type: application/json' \
    --data-raw '{
        "api_key": "<chave de api>",
        "bank_account_id": "<id da nova conta bancaria>"
    }'
    ```
3. Logue na pilot e tente fazer um saque, o custo deve ser igual ao da propriedade `credito_em_conta` retornada em `GET /company`

resolves https://github.com/pagarme/pilot/issues/1602