### PR TITLE
Adjust/onboarding visibility

### DIFF
--- a/packages/pilot/src/containers/Onboarding/ProgressBar/index.js
+++ b/packages/pilot/src/containers/Onboarding/ProgressBar/index.js
@@ -1,7 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import {
+  __,
+  always,
+  cond,
+  gt,
+  T,
+} from 'ramda'
 import { SecondaryLinearProgress } from 'former-kit'
 import styles from './styles.css'
+
+const setSkipVisibility = cond([
+  [gt(__, 60), always('unset')],
+  [T, always('hidden')],
+])
 
 const ProgressBar = ({
   onSkipOnboarding,
@@ -17,6 +29,9 @@ const ProgressBar = ({
     />
     <button
       className={styles.skipOnboarding}
+      style={{
+        visibility: setSkipVisibility(progressPercent),
+      }}
       onClick={onSkipOnboarding}
       role="link"
       type="button"


### PR DESCRIPTION
## Contexto

Este PR torna obrigatória as quatro primeiras perguntas do Onboarding.

Alguns usuários acabam skipando o Onboarding durante a primeira tela, entretanto, o time do Risco e Ativação consideraram as primeiras perguntas do fluxo são importantes e, por isso, realizam o pedido para deixarmos estas perguntas obrigatórias.

[Related to Story #588](https://app.clubhouse.io/pagar-me/story/588/tornar-perguntas-obrigat%C3%B3rias-no-formul%C3%A1rio-de-boas-vindas)

## Checklist
- [x] Torna as primeiras perguntas do fluxo obrigatórias.
- [x] Remove a checagem se o usuário já transacionou da tela do EmptyState.

## Issues linkadas
- [x] [Related to Story #588](https://app.clubhouse.io/pagar-me/story/588/tornar-perguntas-obrigat%C3%B3rias-no-formul%C3%A1rio-de-boas-vindas)

## Como testar?
Realizar o fluxo de onboarding com uma conta recem criada (dá para utilizar o email e a company criados na rota POST /companies/temporary) e verificar se a opção para skipar o onboarding está invisivel até a percentagem 60%.