### PR TITLE
Feature/adjust onboarding visibility

### DIFF
--- a/packages/pilot/src/containers/Onboarding/ProgressBar/index.js
+++ b/packages/pilot/src/containers/Onboarding/ProgressBar/index.js
@@ -1,7 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import {
+  __,
+  always,
+  cond,
+  gt,
+  T,
+} from 'ramda'
 import { SecondaryLinearProgress } from 'former-kit'
 import styles from './styles.css'
+
+const setSkipVisibility = cond([
+  [gt(__, 60), always('unset')],
+  [T, always('hidden')],
+])
 
 const ProgressBar = ({
   onSkipOnboarding,
@@ -17,6 +29,9 @@ const ProgressBar = ({
     />
     <button
       className={styles.skipOnboarding}
+      style={{
+        visibility: setSkipVisibility(progressPercent),
+      }}
       onClick={onSkipOnboarding}
       role="link"
       type="button"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7837,9 +7837,9 @@ https-browserify@^1.0.0:
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
 https-proxy-agent@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz#271ea8e90f836ac9f119daccd39c19ff7dfb0793"
-  integrity sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
+  integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"


### PR DESCRIPTION
## Contexto

Este PR torna obrigatória as quatro primeiras perguntas do Onboarding.

Alguns usuários acabam skipando o Onboarding durante a primeira tela, entretanto, o time do Risco e Ativação consideraram as primeiras perguntas do fluxo são importantes e, por isso, realizam o pedido para deixarmos estas perguntas obrigatórias.

[Related to Story #588](https://app.clubhouse.io/pagar-me/story/588/tornar-perguntas-obrigat%C3%B3rias-no-formul%C3%A1rio-de-boas-vindas)

## Checklist
- [x] Torna as primeiras perguntas do fluxo obrigatórias.
- [x] Remove a checagem se o usuário já transacionou da tela do EmptyState.

## Issues linkadas
- [x] [Related to Story #588](https://app.clubhouse.io/pagar-me/story/588/tornar-perguntas-obrigat%C3%B3rias-no-formul%C3%A1rio-de-boas-vindas)

## Como testar?
Realizar o fluxo de onboarding com uma conta recem criada (dá para utilizar o email e a company criados na rota POST /companies/temporary) e verificar se a opção para skipar o onboarding está invisivel até a percentagem 60%.