### PR TITLE
Add/payment links menu

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -1622,6 +1622,9 @@
       "total_amount": "total capturado de",
       "try_again": "Tente novamente com outros filtros."
     },
+    "payment_links": {
+      "title": "Links De Pagamento"
+    },
     "empty_state": {
       "title": "Boas-vindas",
       "welcome": {

--- a/packages/pilot/src/pages/LoggedArea/Sidebar.js
+++ b/packages/pilot/src/pages/LoggedArea/Sidebar.js
@@ -41,6 +41,7 @@ const Sidebar = ({
   // anticipationLimit,
   balance,
   companyCapabilities,
+  companyId,
   companyName,
   history,
   location: { pathname },
@@ -53,10 +54,15 @@ const Sidebar = ({
     balance={balance}
     companyName={companyName}
     links={values(routes)
-      .filter(({ hidden, validateVisibility }) => {
+      .filter(({ hidden, path, validateVisibility }) => {
         if (validateVisibility) {
           return validateVisibility(companyCapabilities)
         }
+
+        if (path === '/payment-links' && companyId === '5e8f606e2e684d1e268ad05e') {
+          return true
+        }
+
         return !hidden
       })
       .map(route => ({
@@ -90,6 +96,7 @@ Sidebar.propTypes = {
   companyCapabilities: PropTypes.shape({
     allow_manage_recipient: PropTypes.bool,
   }),
+  companyId: PropTypes.string,
   companyName: PropTypes.string,
   history: PropTypes.shape({
     push: PropTypes.func,
@@ -112,6 +119,7 @@ Sidebar.defaultProps = {
   // More details in issue #1159
   // anticipationLimit: null,
   companyCapabilities: {},
+  companyId: '',
   companyName: '',
   recipientId: null,
   sessionId: '',

--- a/packages/pilot/src/pages/LoggedArea/dynamicImports.js
+++ b/packages/pilot/src/pages/LoggedArea/dynamicImports.js
@@ -36,6 +36,10 @@ const EmptyState = lazy(() => import(
   /* webpackChunkName: "empty-state" */ '../EmptyState/EmptyState'
 ))
 
+const PaymentLinks = lazy(() => import(
+  /* webpackChunkName: "payment-links" */ '../PaymentLinks/PaymentLinks'
+))
+
 export {
   Anticipation,
   Balance,
@@ -46,4 +50,5 @@ export {
   Transactions,
   UserSettings,
   Withdraw,
+  PaymentLinks,
 }

--- a/packages/pilot/src/pages/LoggedArea/index.js
+++ b/packages/pilot/src/pages/LoggedArea/index.js
@@ -31,6 +31,7 @@ const getRecipientId = path(['account', 'company', 'default_recipient_id', env])
 const getBalance = path(['account', 'balance'])
 const getCompanyCapabilities = path(['account', 'company', 'capabilities'])
 const getCompanyName = path(['account', 'company', 'name'])
+const getCompanyId = path(['account', 'company', 'id'])
 const getAccountSessionId = path(['account', 'sessionId'])
 const getTransfersPricing = path(['account', 'company', 'pricing', 'transfers'])
 
@@ -42,6 +43,7 @@ const mapStateToProps = applySpec({
   // anticipationLimit: getAnticipationLimit,
   balance: getBalance,
   companyCapabilities: getCompanyCapabilities,
+  companyId: getCompanyId,
   companyName: getCompanyName,
   recipientId: getRecipientId,
   sessionId: getAccountSessionId,
@@ -62,6 +64,7 @@ const LoggedArea = ({
   // anticipationLimit,
   balance,
   companyCapabilities,
+  companyId,
   companyName,
   recipientId,
   sessionId,
@@ -77,6 +80,7 @@ const LoggedArea = ({
         // More details in issue #1159
         // anticipationLimit={anticipationLimit}
         companyCapabilities={companyCapabilities}
+        companyId={companyId}
         companyName={companyName}
         balance={balance}
         recipientId={recipientId}
@@ -124,6 +128,7 @@ LoggedArea.propTypes = {
   companyCapabilities: PropTypes.shape({
     allow_manage_recipient: PropTypes.bool,
   }),
+  companyId: PropTypes.string,
   companyName: PropTypes.string,
   recipientId: PropTypes.string,
   sessionId: PropTypes.string,
@@ -141,6 +146,7 @@ LoggedArea.defaultProps = {
   // anticipationLimit: null,
   balance: {},
   companyCapabilities: {},
+  companyId: '',
   companyName: '',
   recipientId: null,
   sessionId: '',

--- a/packages/pilot/src/pages/LoggedArea/routes.js
+++ b/packages/pilot/src/pages/LoggedArea/routes.js
@@ -4,6 +4,7 @@ import Home32 from 'emblematic-icons/svg/Home32.svg'
 import Transaction32 from 'emblematic-icons/svg/Transaction32.svg'
 import Withdraw32 from 'emblematic-icons/svg/Withdraw32.svg'
 import Store32 from 'emblematic-icons/svg/Store32.svg'
+import Link32 from 'emblematic-icons/svg/Link32.svg'
 
 import {
   Anticipation,
@@ -15,6 +16,7 @@ import {
   Transactions,
   UserSettings,
   Withdraw,
+  PaymentLinks,
 } from './dynamicImports'
 
 /* eslint-disable sort-keys */
@@ -56,6 +58,13 @@ export default {
     icon: Transaction32,
     path: '/transactions',
     title: 'pages.transactions.title',
+  },
+  paymentLinks: {
+    component: PaymentLinks,
+    hidden: true,
+    path: '/payment-links',
+    title: 'pages.payment_links.title',
+    icon: Link32,
   },
   companySettings: {
     component: CompanySettings,

--- a/packages/pilot/src/pages/PaymentLinks/PaymentLinks.js
+++ b/packages/pilot/src/pages/PaymentLinks/PaymentLinks.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const PaymentLinks = () => (<div>links de pagamento</div>)
+
+export default PaymentLinks


### PR DESCRIPTION
##  Contexto

Esse PR adiciona um item de menu na side bar para a página de Links De Pagamento, com uma condicional que o deixa visível apenas para uma company de teste cujo ID é 5e8f606e2e684d1e268ad05e.

Essa condicional será removida antes do envio para live.

## Checklist
- [x] Adicionado um item de menu para a tela de Link De Pagamento
- [x] Adicionado regra de visibilidade para o novo item de menu

## Issues linkadas
- [x] Resolve https://app.clubhouse.io/pagar-me/story/642/adicionar-link-de-pagamento-no-menu-da-pilot

## Como testar?
Acessar a home e verificar se para uma company diferente da mencionada acima o menu continuará escondido.