### PR TITLE
chore: remove underline from a tag

### DIFF
--- a/packages/pilot/src/containers/EmptyState/InfoCard/styles.css
+++ b/packages/pilot/src/containers/EmptyState/InfoCard/styles.css
@@ -4,8 +4,9 @@
   flex-wrap: nowrap;
 }
 
-.infoCard a {
-  text-decoration: underline;
+.infoCard a,
+.infoCard a:hover {
+  text-decoration: none;
 }
 
 .infoCard button {


### PR DESCRIPTION
## Contexto

Remove a linha roxa debaixo dos botões de link do emptyState.

## Checklist
- [ ] Remove a linha roxa debaixo dos botões de link do emptyState.

## Screenshots
### Layout:
<!-- Insira o layout do Zeplin desta tarefa. -->
![image](https://user-images.githubusercontent.com/13531067/83047247-79bb4300-a01e-11ea-963c-1089c311a95b.png)


### Preview:
<!-- Adicione quando não há um snapshot no Percy. -->
![image](https://user-images.githubusercontent.com/13531067/83047265-7fb12400-a01e-11ea-9a10-b6e0dfde0d30.png)
