### PR TITLE
EXP-100 feat(login): allow payment_link_app company to login

### DIFF
--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -58,7 +58,6 @@ const hasDashboardAccess = ifElse(
   path(['client', 'authentication', 'allow_dashboard_login']),
   allPass([
     pathNotEq(['company', 'type'], 'mei'),
-    pathNotEq(['company', 'type'], 'payment_link_app'),
   ])
 )
 


### PR DESCRIPTION
## Contexto
Removendo trava que impede clientes Link.me de acessar a dashboard.

## Como testar
- [ ] Logar com conta Link.me.
