### PR TITLE
EXP-100 payment_link_app: removing buttons

### DIFF
--- a/packages/pilot/src/containers/Header/index.js
+++ b/packages/pilot/src/containers/Header/index.js
@@ -38,6 +38,7 @@ const getEnvironmentUrl = () => (
 )
 
 const renderEnvironmentButton = ({
+  companyType,
   t,
 }) => (
   <Popover
@@ -53,25 +54,31 @@ const renderEnvironmentButton = ({
     )}
     placement="bottomEnd"
   >
-    {environment === 'test'
+    {environment === 'test' && companyType !== 'payment_link_app'
       && (
         <small className={style.testEnvironmentLabel}>
           {t('header.environment.test_environment')}
         </small>
       )
     }
-    <Button
-      fill="clean"
-      icon={
-        environment === 'test'
-          ? <IconTestAmbientOn />
-          : <IconTestAmbientOff />
-      }
-    />
+    {
+      companyType !== 'payment_link_app'
+      && (
+        <Button
+          fill="clean"
+          icon={
+            environment === 'test'
+              ? <IconTestAmbientOn />
+              : <IconTestAmbientOff />
+          }
+        />
+      )
+    }
   </Popover>
 )
 
 const HeaderContainer = ({
+  companyType,
   onBack,
   onLogout,
   onSettings,
@@ -122,7 +129,7 @@ const HeaderContainer = ({
         </>
       )}
 
-      {renderEnvironmentButton({ t })}
+      {renderEnvironmentButton({ companyType, t })}
 
       <Spacing size="small" />
 
@@ -154,10 +161,16 @@ const HeaderContainer = ({
 )
 
 renderEnvironmentButton.propTypes = {
+  companyType: PropTypes.string,
   t: PropTypes.func.isRequired,
 }
 
+renderEnvironmentButton.defaultProps = {
+  companyType: '',
+}
+
 HeaderContainer.propTypes = {
+  companyType: PropTypes.string,
   onBack: PropTypes.func.isRequired,
   onLogout: PropTypes.func.isRequired,
   onSettings: PropTypes.func.isRequired,
@@ -174,6 +187,10 @@ HeaderContainer.propTypes = {
     email: PropTypes.string,
     name: PropTypes.string,
   }).isRequired,
+}
+
+HeaderContainer.defaultProps = {
+  companyType: '',
 }
 
 export default HeaderContainer

--- a/packages/pilot/src/containers/Sidebar/index.js
+++ b/packages/pilot/src/containers/Sidebar/index.js
@@ -95,6 +95,7 @@ class SidebarContainer extends React.Component {
     } = this.state
     const {
       companyName,
+      companyType,
       links,
       logo: Logo,
       onLinkClick,
@@ -183,7 +184,7 @@ class SidebarContainer extends React.Component {
             />
           ))}
         </SidebarLinks>
-        {!collapsed
+        {!collapsed && companyType !== 'payment_link_app'
           && (
             <Flexbox
               className={style.backToOldVersion}
@@ -218,6 +219,7 @@ SidebarContainer.propTypes = {
     waitingFunds: PropTypes.number,
   }).isRequired,
   companyName: PropTypes.string,
+  companyType: PropTypes.string,
   links: PropTypes.arrayOf(PropTypes.shape({
     active: PropTypes.bool,
     component: isValidElement,
@@ -242,6 +244,7 @@ SidebarContainer.defaultProps = {
   // More details in issue #1159
   // anticipationLimit: null,
   companyName: '',
+  companyType: '',
   onWithdraw: null,
   sessionId: '',
   transfersPricing: {},

--- a/packages/pilot/src/pages/LoggedArea/Header.js
+++ b/packages/pilot/src/pages/LoggedArea/Header.js
@@ -53,6 +53,7 @@ const Header = ({
 
   return (
     <HeaderContainer
+      companyType={company.type}
       onBack={goBack}
       onLogout={onLogout}
       onSettings={() => push(routes.accountSettings.path)}

--- a/packages/pilot/src/pages/LoggedArea/Sidebar.js
+++ b/packages/pilot/src/pages/LoggedArea/Sidebar.js
@@ -42,6 +42,7 @@ const Sidebar = ({
   balance,
   companyCapabilities,
   companyName,
+  companyType,
   history,
   location: { pathname },
   recipientId,
@@ -52,6 +53,7 @@ const Sidebar = ({
   <SidebarContainer
     balance={balance}
     companyName={companyName}
+    companyType={companyType}
     links={values(routes)
       .filter(({ hidden, validateVisibility }) => {
         if (validateVisibility) {
@@ -91,6 +93,7 @@ Sidebar.propTypes = {
     allow_manage_recipient: PropTypes.bool,
   }),
   companyName: PropTypes.string,
+  companyType: PropTypes.string,
   history: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,
@@ -113,6 +116,7 @@ Sidebar.defaultProps = {
   // anticipationLimit: null,
   companyCapabilities: {},
   companyName: '',
+  companyType: '',
   recipientId: null,
   sessionId: '',
   transfersPricing: {},

--- a/packages/pilot/src/pages/LoggedArea/index.js
+++ b/packages/pilot/src/pages/LoggedArea/index.js
@@ -31,6 +31,7 @@ const getRecipientId = path(['account', 'company', 'default_recipient_id', env])
 const getBalance = path(['account', 'balance'])
 const getCompanyCapabilities = path(['account', 'company', 'capabilities'])
 const getCompanyName = path(['account', 'company', 'name'])
+const getCompanyType = path(['account', 'company', 'type'])
 const getAccountSessionId = path(['account', 'sessionId'])
 const getTransfersPricing = path(['account', 'company', 'pricing', 'transfers'])
 
@@ -43,6 +44,7 @@ const mapStateToProps = applySpec({
   balance: getBalance,
   companyCapabilities: getCompanyCapabilities,
   companyName: getCompanyName,
+  companyType: getCompanyType,
   recipientId: getRecipientId,
   sessionId: getAccountSessionId,
   transfersPricing: getTransfersPricing,
@@ -63,6 +65,7 @@ const LoggedArea = ({
   balance,
   companyCapabilities,
   companyName,
+  companyType,
   recipientId,
   sessionId,
   t,
@@ -78,6 +81,7 @@ const LoggedArea = ({
         // anticipationLimit={anticipationLimit}
         companyCapabilities={companyCapabilities}
         companyName={companyName}
+        companyType={companyType}
         balance={balance}
         recipientId={recipientId}
         sessionId={sessionId}
@@ -124,6 +128,7 @@ LoggedArea.propTypes = {
     allow_manage_recipient: PropTypes.bool,
   }),
   companyName: PropTypes.string,
+  companyType: PropTypes.string,
   recipientId: PropTypes.string,
   sessionId: PropTypes.string,
   t: PropTypes.func.isRequired,
@@ -141,6 +146,7 @@ LoggedArea.defaultProps = {
   balance: {},
   companyCapabilities: {},
   companyName: '',
+  companyType: '',
   recipientId: null,
   sessionId: '',
   transfersPricing: {},


### PR DESCRIPTION
## Contexto
Removendo os seguintes botões quando cliente Link.me acessar a dash:
- [x] Voltar para versão 1.0
- [x] Ir para dashboard de teste

## Como testar?
- Logar com company do type `payment_link_app`;
- Não deverá ser mostrado no header a informação do ambiente que vc está;
- Não deverá ser mostrado no site o botão para voltar pra dash antiga.