### PR TITLE
EXP-97 chore: hidden api key to customers of payment link

### DIFF
--- a/packages/pilot/src/containers/Settings/Company/GeneralInfoTab/index.js
+++ b/packages/pilot/src/containers/Settings/Company/GeneralInfoTab/index.js
@@ -12,6 +12,7 @@ const GeneralInfoTab = ({
   apiVersion,
   environment,
   fees,
+  hiddenApiKey,
   isMDRzao,
   onVersionChange,
   t,
@@ -27,15 +28,19 @@ const GeneralInfoTab = ({
       />
     </CardContent>
 
-    <CardContent>
-      <ApiKey
-        apiKeys={apiKeys}
-        environment={environment}
-        t={t}
-      />
-    </CardContent>
+    {!hiddenApiKey
+      && (
+        <CardContent>
+          <ApiKey
+            apiKeys={apiKeys}
+            environment={environment}
+            t={t}
+          />
+        </CardContent>
+      )
+    }
 
-    {!userIsReadOnly
+    {!userIsReadOnly && !hiddenApiKey
       && (
         <CardContent>
           <Versions
@@ -76,6 +81,7 @@ GeneralInfoTab.propTypes = {
     })),
     transfer: PropTypes.number,
   }).isRequired,
+  hiddenApiKey: PropTypes.bool.isRequired,
   isMDRzao: PropTypes.bool.isRequired,
   onVersionChange: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,

--- a/packages/pilot/src/containers/Settings/Company/index.js
+++ b/packages/pilot/src/containers/Settings/Company/index.js
@@ -48,6 +48,7 @@ class CompanySettings extends Component {
       general,
       handleCreateUser,
       handleDeleteUser,
+      hiddenApiKey,
       isMDRzao,
       managingPartner,
       onBankAccountCancel,
@@ -90,6 +91,7 @@ class CompanySettings extends Component {
               apiVersion={apiVersion}
               environment={environment}
               fees={fees}
+              hiddenApiKey={hiddenApiKey}
               isMDRzao={isMDRzao}
               onVersionChange={onVersionChange}
               t={t}
@@ -256,6 +258,7 @@ CompanySettings.propTypes = {
   }).isRequired,
   handleCreateUser: PropTypes.func.isRequired,
   handleDeleteUser: PropTypes.func.isRequired,
+  hiddenApiKey: PropTypes.bool.isRequired,
   isMDRzao: PropTypes.bool.isRequired,
   managingPartner: PropTypes.shape({
     cpf: PropTypes.string,

--- a/packages/pilot/src/pages/CompanySettings/index.js
+++ b/packages/pilot/src/pages/CompanySettings/index.js
@@ -141,6 +141,7 @@ const defaultBankAccountErrorsState = {
 }
 
 const userIsReadOnly = propEq('permission', 'read_only')
+const hiddenApiKey = propEq('type', 'payment_link_app')
 
 class CompanySettingsPage extends React.Component {
   constructor (props) {
@@ -568,6 +569,7 @@ class CompanySettingsPage extends React.Component {
 
   render () {
     const {
+      company,
       fees,
       isMDRzao,
       t,
@@ -616,6 +618,7 @@ class CompanySettingsPage extends React.Component {
         general={general}
         handleCreateUser={this.handleCreateUser}
         handleDeleteUser={this.handleDeleteUser}
+        hiddenApiKey={hiddenApiKey(company)}
         isMDRzao={isMDRzao}
         managingPartner={managingPartner}
         onBankAccountCancel={this.handleAccountCancel}
@@ -674,7 +677,9 @@ CompanySettingsPage.propTypes = {
 }
 
 CompanySettingsPage.defaultProps = {
-  company: null,
+  company: {
+    type: null,
+  },
   fees: {},
   isMDRzao: false,
   user: null,


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->
Este PR oculta o card de api_key e encryption_key da pilot para os clientes com o type `payment_link_app`

## Checklist
- [ ] ocultar api key para companies do link app
- [ ] ocultar versão da api para companies do link app

<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [ ]  [EXP-97](https://mundipagg.atlassian.net/browse/EXP-97?atlOrigin=eyJpIjoiM2YwYzc0Y2ZlYzc4NDhhNWFkMWNiNTZlNDMwZTY2MTEiLCJwIjoiaiJ9)

<!-- Adicione as respectivas issues linkadas a este PR. -->

## Screenshots
<!-- Adicione algumas imagens para haver um preview da sua tarefa, para ajudar desenvolvedores e designers a entender facilmente no que você está trabalhando. -->
![image](https://user-images.githubusercontent.com/20932604/86246386-4ae63e80-bb81-11ea-94c9-ebcd62addcdb.png)


### Preview:
<!-- Adicione quando não há um snapshot no Percy. -->
![image](https://user-images.githubusercontent.com/20932604/86246331-330eba80-bb81-11ea-8eb0-e70e118fd88c.png)

## Notas de deploy
<!-- Notas de deploy do desenvolvimento da aplicação. Devem ser novas dependências, scripts, etc. -->

## Como testar?
- [ ] Iogar com uma company normal e verificar se está mostrando
- [ ] logar com uma company com o type `payment_link_app` e checar se o campo fica oculto