### PR TITLE
plinks: update total_paid column label

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -1655,7 +1655,7 @@
         "link_name": "nome do link",
         "created_at": "data de criação",
         "link": "link",
-        "total_paid": "valor total",
+        "total_paid": "valor pago",
         "status_legends": {
           "active": "ativo",
           "canceled": "inativo",


### PR DESCRIPTION
## Contexto

Atualiza a label da coluna `Valor Total` da listagem de link de pagamentos para `Valor Pago`.

## Issues linkadas
- [ ] Resolves [CRED-177](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=186&projectKey=CRED&modal=detail&selectedIssue=CRED-177)
