### PR TITLE
EXP-143 Add zoopim tags

### DIFF
--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -25,6 +25,7 @@ import cockpit from 'cockpit'
 import env from '../../../environment'
 import identifyUser from '../../../vendor/identifyUser'
 import setCompany from '../../../vendor/setCompany'
+import { zopimAddTags, zopimClearAll } from '../../../vendor/zopim'
 import {
   ACCOUNT_RECEIVE,
   COMPANY_RECEIVE,
@@ -141,6 +142,8 @@ const accountEpic = action$ => action$
         permission,
         env
       )
+
+      zopimAddTags([`nível de acesso do usuário: ${permission}`])
     })
   )
 
@@ -236,6 +239,12 @@ const companyEpic = (action$, state$) => action$.pipe(
       userId
     )
 
+    zopimAddTags([
+      `tipo da company: ${type}`,
+      `id da company: ${id}`,
+      'Aplicação: dashboard beta',
+    ])
+
     if (status === 'active') {
       activeCompanyLogin()
     } else {
@@ -278,6 +287,8 @@ const logoutEpic = (action$, state$) => action$.pipe(
         sessionId,
       },
     } = state
+
+    zopimClearAll()
 
     return client.session
       .destroy(sessionId)

--- a/packages/pilot/src/vendor/zopim.js
+++ b/packages/pilot/src/vendor/zopim.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-undef */
+import hasProperty from './hasProperty'
+
+/**
+ * Add tags do zoopim chat
+ *
+ * @param {array} tags array of tags to add
+ */
+export const zopimAddTags = (tags) => {
+  if (hasProperty(window.$zopim)) {
+    window.$zopim(() => {
+      window.$zopim.livechat.addTags(...tags)
+    })
+  }
+}
+
+/**
+ * Clear all zopim current user data
+ */
+export const zopimClearAll = () => {
+  if (hasProperty(window.$zopim)) {
+    window.$zopim(() => {
+      window.$zopim.livechat.clearAll()
+    })
+  }
+}
+


### PR DESCRIPTION
Este pr adiciona as tags ao chat do zoopim para facilitar o atendimento do RC
as tags adicionadas foram:
- id da company
- tipo da company
- permissão do usuário
- aplicação: dashboard beta

### como testar
- baixar. a branch
- subir a dashboard localmente
- efetuar login
- iniciar um atendimento do chat (combinar com o rc antes de fazer isso)
- verificar se os dados apareceram corretamente para a pessoa do rc

esse fluxo foi testando com o Italo do rc onde eu o @andrecondessa e o @Matheus-Maciel  testamos em call