### PR TITLE
EXP-95 chore: remove onboarding company payment-link-app

### DIFF
--- a/packages/pilot/src/pages/EmptyState/EmptyState.js
+++ b/packages/pilot/src/pages/EmptyState/EmptyState.js
@@ -26,6 +26,7 @@ import { selectCompanyFees } from '../Account/actions/reducer'
 const getUserName = pipe(prop('name'), split(' '), head)
 
 const hasAdminPermission = propEq('permission', 'admin')
+const isPaymentLink = propEq('type', 'payment_link_app')
 
 const getAccessKeys = applySpec({
   apiKey: path(['api_key', environment]),
@@ -49,6 +50,7 @@ const mapStateToProps = ({
 }) => ({
   accessKeys: getAccessKeys(company),
   alreadyTransacted: getAlreadyTransacted(company),
+  company,
   fees: selectCompanyFees(company),
   isAdmin: hasAdminPermission(user),
   isMDRzao: company && propEq('anticipationType', 'MDRZAO', company),
@@ -78,6 +80,7 @@ const shouldRedirectToOnboarding = (alreadyTransacted, onboardingAnswers) => {
 const EmptyState = ({
   accessKeys,
   alreadyTransacted,
+  company,
   fees,
   history: {
     push,
@@ -94,12 +97,21 @@ const EmptyState = ({
   }, [requestOnboardingAnswers])
 
   useEffect(() => {
-    if (onboardingAnswers
+    if (
+      onboardingAnswers
       && isAdmin
-      && shouldRedirectToOnboarding(alreadyTransacted, onboardingAnswers)) {
+      && shouldRedirectToOnboarding(alreadyTransacted, onboardingAnswers)
+      && !isPaymentLink(company)
+    ) {
       push('/onboarding')
     }
-  }, [alreadyTransacted, isAdmin, onboardingAnswers, push])
+  }, [
+    alreadyTransacted,
+    company,
+    isAdmin,
+    onboardingAnswers,
+    push,
+  ])
 
   return (
     <EmptyStateContainer
@@ -123,6 +135,9 @@ EmptyState.propTypes = {
     encryptionKey: PropTypes.string,
   }),
   alreadyTransacted: PropTypes.bool,
+  company: PropTypes.shape({
+    type: PropTypes.string,
+  }),
   fees: PropTypes.shape({
     anticipation: PropTypes.number,
     antifraud: PropTypes.number,
@@ -148,6 +163,9 @@ EmptyState.propTypes = {
 EmptyState.defaultProps = {
   accessKeys: {},
   alreadyTransacted: true,
+  company: {
+    type: null,
+  },
   fees: {},
   isMDRzao: false,
   onboardingAnswers: undefined,


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->
Nesse Pr ocultamos o onboarding de perguntas sobre a company para companies do link

## Checklist
- [ ] Não mostrar onboarding para companies link
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [ ] Resolves #https://mundipagg.atlassian.net/browse/EXP-95?atlOrigin=eyJpIjoiN2UxMTIxYWE1OTliNGJjMGIxMmVhOTQ4ZDRlMTEwYTIiLCJwIjoiaiJ9


## Como testar?
Para testar esse PR você precisar criar um campany pelo auto-cred e pelo link.app para testar se o onboarding está sendo mostrado ou não
 
Para logar com as companies do link precisamos comentar a linha 97 desse arquivo
https://github.com/pagarme/pilot/blob/0000000000000000000000000000000000000000%3A/packages/pilot/src/pages/Account/actions/epic.js#L97
e adicionar um eslint-disable no começo da página