### PR TITLE
EXP-145 - Corrige erro de ambiente inválido para companies não ativas

### DIFF
--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -182,7 +182,7 @@ const companyEpic = (action$, state$) => action$.pipe(
   }),
   mergeMap((action) => {
     if (action.error) {
-      return action
+      return rxOf(action)
     }
 
     const { value: state } = state$


### PR DESCRIPTION
## Contexto
Hoje o erro de ambiente inválido para companies não `active` não está sendo exibido. Isto ocorre pois em um dos Observers do `companyEpic` não estamos retornando um `Observable`, assim consequentemente nenhuma ação de erro do redux é disparada. Este PR adiciona este retorno de `Observable` ao nosso epico.

## Checklist
- [x] Adiciona o uso do `rxOf` para retornar um `Observable` no `companyEpic`

## Como testar?
1. Suba a aplicação em modo `live`:

```bash
env REACT_APP_API_ENVIRONMENT=live yarn start
```

2. Faça o login com uma company com status diferente de `active`