### PR TITLE
CRED-13 Ajuste no CTA de "Voltar para a Dashboard legada"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @pagarme/green-phoenix @pagarme/credenciamento

--- a/packages/pilot/package.json
+++ b/packages/pilot/package.json
@@ -11,7 +11,7 @@
     "cpf_cnpj": "0.2.0",
     "emblematic-icons": "0.9.0",
     "former-kit": "2.2.0",
-    "former-kit-skin-pagarme": "2.1.1",
+    "former-kit-skin-pagarme": "2.2.0",
     "i18next": "13.1.2",
     "i18next-browser-languagedetector": "2.2.4",
     "i18next-xhr-backend": "1.5.1",

--- a/packages/pilot/package.json
+++ b/packages/pilot/package.json
@@ -9,7 +9,7 @@
     "clipboard-copy": "2.0.0",
     "cockpit": "0.0.1",
     "cpf_cnpj": "0.2.0",
-    "emblematic-icons": "0.8.1",
+    "emblematic-icons": "0.9.0",
     "former-kit": "2.2.0",
     "former-kit-skin-pagarme": "2.1.1",
     "i18next": "13.1.2",

--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -1192,7 +1192,7 @@
     "sidebar": {
       "available": "Disponível para saque",
       "balance": "Saldo",
-      "back_to_old_version": "Voltar para versão 1.0",
+      "back_to_old_version": "Voltar para a dashboard legada",
       "currency_symbol": "R$",
       "hide_balance": "Ocultar saldo",
       "show_balance": "Mostrar saldo",

--- a/packages/pilot/src/containers/Sidebar/index.js
+++ b/packages/pilot/src/containers/Sidebar/index.js
@@ -196,6 +196,7 @@ class SidebarContainer extends React.Component {
                 }
                 fill="outline"
                 size="tiny"
+                relevance="low"
               >
                 {t('pages.sidebar.back_to_old_version')}
               </Button>

--- a/packages/pilot/src/containers/Sidebar/style.css
+++ b/packages/pilot/src/containers/Sidebar/style.css
@@ -2,7 +2,8 @@
 @import "former-kit-skin-pagarme/dist/styles/spacing.css";
 
 .backToOldVersion {
-  margin-top: var(--spacing-medium);
+  bottom: var(--spacing-large);
+  position: absolute;
 }
 
 .sidebarIcon {

--- a/packages/pilot/src/pages/LoggedArea/routes.js
+++ b/packages/pilot/src/pages/LoggedArea/routes.js
@@ -73,13 +73,6 @@ export default {
     path: '/payment-links/:id',
     title: 'pages.payment_link_detail.title',
   },
-  companySettings: {
-    component: CompanySettings,
-    exact: true,
-    icon: Configuration32,
-    path: '/settings',
-    title: 'pages.settings.company.menu',
-  },
   transactionsDetails: {
     exact: true,
     hidden: true,
@@ -119,6 +112,13 @@ export default {
     hidden: true,
     path: '/welcome',
     title: 'pages.empty_state.title',
+  },
+  companySettings: {
+    component: CompanySettings,
+    exact: true,
+    icon: Configuration32,
+    path: '/settings',
+    title: 'pages.settings.company.menu',
   },
 }
 

--- a/packages/pilot/src/pages/LoggedArea/routes.js
+++ b/packages/pilot/src/pages/LoggedArea/routes.js
@@ -1,9 +1,9 @@
-import Balance32 from 'emblematic-icons/svg/Extract32.svg'
-import Configuration32 from 'emblematic-icons/svg/Configuration32.svg'
+import HeartRate32 from 'emblematic-icons/svg/HeartRate32.svg'
+import Wrench32 from 'emblematic-icons/svg/Wrench32.svg'
 import Home32 from 'emblematic-icons/svg/Home32.svg'
-import Transaction32 from 'emblematic-icons/svg/Transaction32.svg'
+import Checkout32 from 'emblematic-icons/svg/Checkout32.svg'
 import Withdraw32 from 'emblematic-icons/svg/Withdraw32.svg'
-import Store32 from 'emblematic-icons/svg/Store32.svg'
+import Anticipation32 from 'emblematic-icons/svg/Anticipation32.svg'
 import Link32 from 'emblematic-icons/svg/Link32.svg'
 
 import {
@@ -25,7 +25,7 @@ export default {
     component: UserSettings,
     exact: true,
     hidden: true,
-    icon: Configuration32,
+    icon: Wrench32,
     path: '/account',
     title: 'pages.settings.user.menu',
   },
@@ -33,7 +33,7 @@ export default {
     component: Anticipation,
     exact: true,
     hidden: true,
-    icon: Balance32,
+    icon: HeartRate32,
     path: '/anticipation/:id?',
     title: 'pages.anticipation.title',
   },
@@ -48,14 +48,14 @@ export default {
   balance: {
     component: Balance,
     exact: true,
-    icon: Balance32,
+    icon: HeartRate32,
     path: '/balance/:id?',
     title: 'pages.balance.title',
   },
   transactions: {
     component: Transactions,
     exact: true,
-    icon: Transaction32,
+    icon: Checkout32,
     path: '/transactions',
     title: 'pages.transactions.title',
   },
@@ -94,7 +94,7 @@ export default {
     title: 'pages.recipients.title',
     path: '/recipients',
     component: Recipients,
-    icon: Store32,
+    icon: Anticipation32,
     exact: true,
   },
   recipientsAdd: {
@@ -116,7 +116,7 @@ export default {
   companySettings: {
     component: CompanySettings,
     exact: true,
-    icon: Configuration32,
+    icon: Wrench32,
     path: '/settings',
     title: 'pages.settings.company.menu',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7038,10 +7038,10 @@ former-kit-skin-pagarme@2.1.0:
     emblematic-icons "0.7.1"
     react-dates "18.4.1"
 
-former-kit-skin-pagarme@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-2.1.1.tgz#930500092d2253d3daf30462294ea7515e3ec5e1"
-  integrity sha512-gi1XtHUM8X+x30GY/q7Kp4TbZFuZO8X2gVyNSs8l+0z/sxH7komiMlX9Awjo57L9Zou4a1EnZKSov/fKyiBdmw==
+former-kit-skin-pagarme@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-2.2.0.tgz#3f00894a923c93f3ac856c4c4fafc11366e4f5b2"
+  integrity sha512-lR0czP1yCPHqI/KFwR/4KR6CdTNnDCTUzEK0tJ4AHbwTGSjaLgMEUKv4OmYRuawZg9J9TKF3o6XxFBJq8c9ZfQ==
   dependencies:
     emblematic-icons "0.7.1"
     react-dates "18.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5778,10 +5778,10 @@ emblematic-icons@0.7.1:
   resolved "https://registry.yarnpkg.com/emblematic-icons/-/emblematic-icons-0.7.1.tgz#2771340af07f31628cb9afc678108fa61542d76e"
   integrity sha512-ZkPYHOhGtwltmeRHnEOA55PK4Cl5fNmTX8kkFqZ6T2MFsZFBle7h8qBfk5gcGxvfQwc/+iRQrwMOGZ86+DooRw==
 
-emblematic-icons@0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/emblematic-icons/-/emblematic-icons-0.8.1.tgz#869ade6dab7344d3d78f4c5f7b0df88e9927afe0"
-  integrity sha512-gFA1G+lwgjihHmwfXpknXqMaEY7AdvbMkpSiAEpNAqyTiPjO6fJ6naFYgNuy1Pw/pFjK/j+YiJl2pHR/6H9XtQ==
+emblematic-icons@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/emblematic-icons/-/emblematic-icons-0.9.0.tgz#c163e959d607336405fda0052f45386a034a2f6a"
+  integrity sha512-CiD9h7/NUaD2c3n104YGyDhnSSMH88RCoHB3//AG8LCu5+hjKFqLNth6YoGmmbUSUVwjDuti7+kOSJ+t6YxOvg==
 
 emoji-regex@^6.5.1:
   version "6.5.1"


### PR DESCRIPTION
## Contexto

Atualmente temos o botão "Voltar para a versão 1.0" na Pilot, o texto desse botão confunde alguns usuários, que acham que ao clicar vão mudar a versão da API.

## Checklist
- [ ] Ajuste no CTA de "Voltar para a Dashboard legada"

## Issues linkadas
- [ ] Resolves [CRED-13](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=186&projectKey=CRED&modal=detail&selectedIssue=CRED-13)
