### PR TITLE
Adjust/onboarding loading

### DIFF
--- a/packages/pilot/src/components/Loader/index.js
+++ b/packages/pilot/src/components/Loader/index.js
@@ -5,24 +5,25 @@ import style from './style.css'
 import Transition from '../Transition'
 import Spinner from '../Spinner'
 
-const createOverlayStyle = position => classNames(
-  style.highZIndex,
+const createOverlayStyle = (opaqueBackground, position) => classNames(
   style.overlay,
-  style[position]
+  style[position],
+  { [style.opaqueBackground]: opaqueBackground }
 )
 
 const Loader = ({
+  opaqueBackground,
   position,
   visible,
 }) => (
   <Transition
     atActive={{
       opacity: 1,
-      zIndex: 10,
+      zIndex: 100,
     }}
     atEnter={{
       opacity: 0.3,
-      zIndex: 10,
+      zIndex: 100,
     }}
     atLeave={{
       opacity: 0,
@@ -38,7 +39,9 @@ const Loader = ({
     {visible
       && (
         <div
-          className={classNames(createOverlayStyle(position), style.spinner)}
+          className={classNames(createOverlayStyle(
+            opaqueBackground, position
+          ), style.spinner)}
           key="overlay"
         >
           <Spinner />
@@ -49,11 +52,13 @@ const Loader = ({
 )
 
 Loader.propTypes = {
+  opaqueBackground: PropTypes.bool,
   position: PropTypes.oneOf(['fixed', 'absolute', 'relative']),
   visible: PropTypes.bool,
 }
 
 Loader.defaultProps = {
+  opaqueBackground: false,
   position: 'fixed',
   visible: false,
 }

--- a/packages/pilot/src/components/Loader/style.css
+++ b/packages/pilot/src/components/Loader/style.css
@@ -23,8 +23,8 @@
   width: 100%;
 }
 
-.highZIndex {
-  z-index: 10;
+.opaqueBackground {
+  background-color: var(--color-squanchy-gray-20);
 }
 
 .spinner > div {

--- a/packages/pilot/src/containers/EmptyState/AccessDocs/index.js
+++ b/packages/pilot/src/containers/EmptyState/AccessDocs/index.js
@@ -46,8 +46,12 @@ const AccessDocs = ({ onboardingAnswers, t }) => {
 AccessDocs.propTypes = {
   onboardingAnswers: PropTypes.shape({
     platform: PropTypes.string,
-  }).isRequired,
+  }),
   t: PropTypes.func.isRequired,
+}
+
+AccessDocs.defaultProps = {
+  onboardingAnswers: {},
 }
 
 export default AccessDocs

--- a/packages/pilot/src/containers/EmptyState/index.js
+++ b/packages/pilot/src/containers/EmptyState/index.js
@@ -84,9 +84,7 @@ EmptyState.propTypes = {
   }),
   isAdmin: PropTypes.bool,
   isMDRzao: PropTypes.bool.isRequired,
-  onboardingAnswers: PropTypes.shape({
-    platform: PropTypes.string.isRequired,
-  }),
+  onboardingAnswers: PropTypes.objectOf(PropTypes.string),
   onDisableWelcome: PropTypes.func,
   t: PropTypes.func.isRequired,
   userName: PropTypes.string,

--- a/packages/pilot/src/pages/EmptyState/EmptyState.js
+++ b/packages/pilot/src/pages/EmptyState/EmptyState.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import {
@@ -16,11 +16,6 @@ import { translate } from 'react-i18next'
 import EmptyStateContainer from '../../containers/EmptyState'
 import { withError } from '../ErrorBoundary'
 import environment from '../../environment'
-import {
-  requestOnboardingAnswers as requestOnboardingAnswersAction,
-} from './actions'
-import isOnboardingComplete from '../../validation/isOnboardingComplete'
-import isPaymentLink from '../../validation/isPaymentLink'
 
 import { selectCompanyFees } from '../Account/actions/reducer'
 
@@ -34,10 +29,6 @@ const getAccessKeys = applySpec({
 })
 
 const getAlreadyTransacted = propOr(true, 'alreadyTransacted')
-
-const mapDispatchToProps = {
-  requestOnboardingAnswers: requestOnboardingAnswersAction,
-}
 
 const mapStateToProps = ({
   account: {
@@ -60,7 +51,7 @@ const mapStateToProps = ({
 
 const enhanced = compose(
   translate(),
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(mapStateToProps, null),
   withError
 )
 
@@ -69,18 +60,8 @@ const hideEmptyState = push => () => {
   return push('/home')
 }
 
-const shouldRedirectToOnboarding = (alreadyTransacted, onboardingAnswers) => {
-  if (localStorage.getItem('skip-onboarding')) {
-    return false
-  }
-
-  return !alreadyTransacted && !isOnboardingComplete(onboardingAnswers)
-}
-
 const EmptyState = ({
   accessKeys,
-  alreadyTransacted,
-  company,
   fees,
   history: {
     push,
@@ -88,55 +69,27 @@ const EmptyState = ({
   isAdmin,
   isMDRzao,
   onboardingAnswers,
-  requestOnboardingAnswers,
   t,
   userName,
-}) => {
-  useEffect(() => {
-    requestOnboardingAnswers()
-  }, [requestOnboardingAnswers])
-
-  useEffect(() => {
-    if (
-      onboardingAnswers
-      && isAdmin
-      && shouldRedirectToOnboarding(alreadyTransacted, onboardingAnswers)
-      && !isPaymentLink(company)
-    ) {
-      push('/onboarding')
-    }
-  }, [
-    alreadyTransacted,
-    company,
-    isAdmin,
-    onboardingAnswers,
-    push,
-  ])
-
-  return (
-    <EmptyStateContainer
-      apiKey={accessKeys.apiKey}
-      encryptionKey={accessKeys.encryptionKey}
-      environment={environment}
-      fees={fees}
-      isAdmin={isAdmin}
-      isMDRzao={isMDRzao}
-      onboardingAnswers={onboardingAnswers}
-      onDisableWelcome={hideEmptyState(push)}
-      t={t}
-      userName={userName}
-    />
-  )
-}
+}) => (
+  <EmptyStateContainer
+    apiKey={accessKeys.apiKey}
+    encryptionKey={accessKeys.encryptionKey}
+    environment={environment}
+    fees={fees}
+    isAdmin={isAdmin}
+    isMDRzao={isMDRzao}
+    onboardingAnswers={onboardingAnswers}
+    onDisableWelcome={hideEmptyState(push)}
+    t={t}
+    userName={userName}
+  />
+)
 
 EmptyState.propTypes = {
   accessKeys: PropTypes.shape({
     apiKey: PropTypes.string,
     encryptionKey: PropTypes.string,
-  }),
-  alreadyTransacted: PropTypes.bool,
-  company: PropTypes.shape({
-    type: PropTypes.string,
   }),
   fees: PropTypes.shape({
     anticipation: PropTypes.number,
@@ -155,17 +108,12 @@ EmptyState.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   isMDRzao: PropTypes.bool,
   onboardingAnswers: PropTypes.shape({}),
-  requestOnboardingAnswers: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   userName: PropTypes.string,
 }
 
 EmptyState.defaultProps = {
   accessKeys: {},
-  alreadyTransacted: true,
-  company: {
-    type: null,
-  },
   fees: {},
   isMDRzao: false,
   onboardingAnswers: undefined,

--- a/packages/pilot/src/pages/EmptyState/actions.js
+++ b/packages/pilot/src/pages/EmptyState/actions.js
@@ -14,3 +14,9 @@ export const resetOnboardingAnswers = createAction(ONBOARDING_ANSWERS_RESET)
 
 export const ADD_ONBOARDING_ANSWERS = 'pilot/welcome/ADD_ONBOARDING_ANSWERS'
 export const addOnboardingAnswers = createAction(ADD_ONBOARDING_ANSWERS)
+
+export const FETCHING_ONBOARDING_ANSWERS = 'pilot/welcome/FETCHING_ONBOARDING_ANSWERS'
+export const fetchingOnboardingAnswers = createAction(
+  FETCHING_ONBOARDING_ANSWERS
+)
+

--- a/packages/pilot/src/pages/EmptyState/actions.js
+++ b/packages/pilot/src/pages/EmptyState/actions.js
@@ -3,9 +3,6 @@ import { createAction } from 'redux-actions'
 export const ONBOARDING_ANSWERS_RECEIVE = 'pilot/welcome/ONBOARDING_ANSWERS_RECEIVE'
 export const receiveOnboardingAnswers = createAction(ONBOARDING_ANSWERS_RECEIVE)
 
-export const ONBOARDING_ANSWERS_REQUEST = 'pilot/welcome/ONBOARDING_ANSWERS_REQUEST'
-export const requestOnboardingAnswers = createAction(ONBOARDING_ANSWERS_REQUEST)
-
 export const ONBOARDING_ANSWERS_FAIL = 'pilot/welcome/ONBOARDING_ANSWERS_FAIL'
 export const failOnboardingAnswers = createAction(ONBOARDING_ANSWERS_FAIL)
 

--- a/packages/pilot/src/pages/EmptyState/actions.js
+++ b/packages/pilot/src/pages/EmptyState/actions.js
@@ -11,3 +11,6 @@ export const failOnboardingAnswers = createAction(ONBOARDING_ANSWERS_FAIL)
 
 export const ONBOARDING_ANSWERS_RESET = 'pilot/welcome/ONBOARDING_ANSWERS_RESET'
 export const resetOnboardingAnswers = createAction(ONBOARDING_ANSWERS_RESET)
+
+export const ADD_ONBOARDING_ANSWERS = 'pilot/welcome/ADD_ONBOARDING_ANSWERS'
+export const addOnboardingAnswers = createAction(ADD_ONBOARDING_ANSWERS)

--- a/packages/pilot/src/pages/EmptyState/epic.js
+++ b/packages/pilot/src/pages/EmptyState/epic.js
@@ -6,14 +6,17 @@ import {
 } from 'rxjs/operators'
 import { combineEpics, ofType } from 'redux-observable'
 import {
+  addOnboardingAnswers,
   failOnboardingAnswers,
-  ONBOARDING_ANSWERS_REQUEST,
   receiveOnboardingAnswers,
 } from './actions'
 
+import { LOGIN_RECEIVE } from '../Account/actions/actions'
+import { POST_ANSWER } from '../Onboarding/actions'
+
 const onboardingAnswersEpic = (action$, state$) => action$
   .pipe(
-    ofType(ONBOARDING_ANSWERS_REQUEST),
+    ofType(LOGIN_RECEIVE),
     mergeMap(() => {
       const state = state$.value
       const { account: { client } } = state
@@ -27,4 +30,18 @@ const onboardingAnswersEpic = (action$, state$) => action$
     })
   )
 
-export default combineEpics(onboardingAnswersEpic)
+const postAnswersEpic = (action$, state$) => action$
+  .pipe(
+    ofType(POST_ANSWER),
+    map(({ payload }) => {
+      const state = state$.value
+      const { onboarding: { question } } = state
+
+      return {
+        [question.label]: payload.answer,
+      }
+    }),
+    map(addOnboardingAnswers)
+  )
+
+export default combineEpics(onboardingAnswersEpic, postAnswersEpic)

--- a/packages/pilot/src/pages/EmptyState/epic.js
+++ b/packages/pilot/src/pages/EmptyState/epic.js
@@ -9,6 +9,7 @@ import {
   addOnboardingAnswers,
   failOnboardingAnswers,
   receiveOnboardingAnswers,
+  fetchingOnboardingAnswers,
 } from './actions'
 
 import { LOGIN_RECEIVE } from '../Account/actions/actions'
@@ -30,6 +31,12 @@ const onboardingAnswersEpic = (action$, state$) => action$
     })
   )
 
+const fetchAnswersEpic = action$ => action$
+  .pipe(
+    ofType(LOGIN_RECEIVE),
+    map(fetchingOnboardingAnswers)
+  )
+
 const postAnswersEpic = (action$, state$) => action$
   .pipe(
     ofType(POST_ANSWER),
@@ -44,4 +51,8 @@ const postAnswersEpic = (action$, state$) => action$
     map(addOnboardingAnswers)
   )
 
-export default combineEpics(onboardingAnswersEpic, postAnswersEpic)
+export default combineEpics(
+  fetchAnswersEpic,
+  onboardingAnswersEpic,
+  postAnswersEpic
+)

--- a/packages/pilot/src/pages/EmptyState/reducer.js
+++ b/packages/pilot/src/pages/EmptyState/reducer.js
@@ -1,4 +1,5 @@
 import {
+  ADD_ONBOARDING_ANSWERS,
   ONBOARDING_ANSWERS_RECEIVE,
   ONBOARDING_ANSWERS_RESET,
 } from './actions'
@@ -16,7 +17,18 @@ export default function welcomeReducer (state = makeInitialState(), action) {
 
       return { onboardingAnswers: payload }
     }
+    case ADD_ONBOARDING_ANSWERS: {
+      const {
+        payload,
+      } = action
 
+      return {
+        onboardingAnswers: {
+          ...state.onboardingAnswers,
+          ...payload,
+        },
+      }
+    }
     case ONBOARDING_ANSWERS_RESET: {
       return makeInitialState()
     }

--- a/packages/pilot/src/pages/EmptyState/reducer.js
+++ b/packages/pilot/src/pages/EmptyState/reducer.js
@@ -1,21 +1,37 @@
 import {
   ADD_ONBOARDING_ANSWERS,
+  FETCHING_ONBOARDING_ANSWERS,
   ONBOARDING_ANSWERS_RECEIVE,
   ONBOARDING_ANSWERS_RESET,
+  ONBOARDING_ANSWERS_FAIL,
 } from './actions'
 
 const makeInitialState = () => ({
+  error: null,
+  loading: false,
   onboardingAnswers: undefined,
 })
 
 export default function welcomeReducer (state = makeInitialState(), action) {
   switch (action.type) {
+    case FETCHING_ONBOARDING_ANSWERS: {
+      return {
+        error: null,
+        loading: true,
+        onboardingAnswers: undefined,
+      }
+    }
     case ONBOARDING_ANSWERS_RECEIVE: {
       const {
         payload,
       } = action
 
-      return { onboardingAnswers: payload }
+      return {
+        ...state,
+        error: null,
+        loading: false,
+        onboardingAnswers: payload,
+      }
     }
     case ADD_ONBOARDING_ANSWERS: {
       const {
@@ -23,6 +39,7 @@ export default function welcomeReducer (state = makeInitialState(), action) {
       } = action
 
       return {
+        ...state,
         onboardingAnswers: {
           ...state.onboardingAnswers,
           ...payload,
@@ -33,6 +50,12 @@ export default function welcomeReducer (state = makeInitialState(), action) {
       return makeInitialState()
     }
 
+    case ONBOARDING_ANSWERS_FAIL:
+      return {
+        ...state,
+        error: action.payload,
+        loading: false,
+      }
     default: {
       return state
     }

--- a/packages/pilot/src/pages/Home/Home.js
+++ b/packages/pilot/src/pages/Home/Home.js
@@ -62,8 +62,8 @@ import HomeContainer from '../../containers/Home'
 import icons from '../../models/icons'
 import IndicatorTooltip from '../../components/HomeIndicatorTooltip'
 import statusLegends from '../../models/statusLegends'
-import isRecentlyCreatedUser from '../../validation/recentCreatedUser'
 import isCompanyPaymentLink from '../../validation/isPaymentLink'
+import isRecentlyCreatedCompany from '../../validation/recentCreatedCompany'
 
 import {
   Message,
@@ -509,7 +509,7 @@ const Home = ({
   useEffect(() => {
     if (!isNilOrEmpty(company)
       && !isCompanyPaymentLink(company)
-      && isRecentlyCreatedUser({ company, user })
+      && isRecentlyCreatedCompany({ company })
       && userNotHidEmptyState()
     ) {
       replace('/welcome')

--- a/packages/pilot/src/pages/LoggedArea/Header.js
+++ b/packages/pilot/src/pages/LoggedArea/Header.js
@@ -13,9 +13,9 @@ import { withRouter } from 'react-router-dom'
 
 import routes from './routes'
 import { requestLogout } from '../Account/actions/actions'
-import isRecentlyCreatedUser from '../../validation/recentCreatedUser'
 import isCompanyPaymentLink from '../../validation/isPaymentLink'
 import isNilOrEmpty from '../../validation/isNilOrEmpty'
+import isRecentlyCreatedCompany from '../../validation/recentCreatedCompany'
 
 import HeaderContainer from '../../containers/Header'
 
@@ -51,7 +51,7 @@ const Header = ({
   user,
 }) => {
   const showWelcomeButton = !isNilOrEmpty(company)
-    && isRecentlyCreatedUser({ company, user })
+    && isRecentlyCreatedCompany({ company })
     && isNotWelcomePage(pathname)
     && !isCompanyPaymentLink(company)
 

--- a/packages/pilot/src/pages/Onboarding/Onboarding.js
+++ b/packages/pilot/src/pages/Onboarding/Onboarding.js
@@ -28,9 +28,6 @@ import {
   postOnboardingAnswer as postOnboardingAnswerAction,
   destroyOnboardingAnswer as destroyOnboardingAnswerAction,
 } from './actions'
-import {
-  resetOnboardingAnswers as resetOnboardingAnswersAction,
-} from '../EmptyState/actions'
 import FakeLoader from '../../components/FakeLoader'
 
 const getUserFirstName = pipe(prop('name'), split(' '), head)
@@ -68,7 +65,6 @@ const mapDispatchToProps = {
   destroyOnboardingAnswer: destroyOnboardingAnswerAction,
   postOnboardingAnswer: postOnboardingAnswerAction,
   requestOnboardingQuestion: requestOnboardingQuestionAction,
-  resetOnboardingAnswers: resetOnboardingAnswersAction,
 }
 
 const enhanced = compose(
@@ -93,7 +89,6 @@ const Onboarding = ({
   postOnboardingAnswer,
   question,
   requestOnboardingQuestion,
-  resetOnboardingAnswers,
   t,
   userId,
   userName,
@@ -136,7 +131,6 @@ const Onboarding = ({
     }
 
     if (finalStep) {
-      resetOnboardingAnswers()
       return setShowFakeLoader(true)
     }
 
@@ -201,7 +195,6 @@ Onboarding.propTypes = {
   postOnboardingAnswer: PropTypes.func.isRequired,
   question: PropTypes.shape(),
   requestOnboardingQuestion: PropTypes.func.isRequired,
-  resetOnboardingAnswers: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   userId: PropTypes.string,
   userName: PropTypes.string,

--- a/packages/pilot/src/pages/Onboarding/Onboarding.js
+++ b/packages/pilot/src/pages/Onboarding/Onboarding.js
@@ -93,7 +93,7 @@ const Onboarding = ({
   userId,
   userName,
 }) => {
-  const [showFakeLoader, setShowFakeLoader] = useState(false)
+  const [lastAnswerSubmited, setLastAnswerSubmited] = useState(null)
 
   const machineContext = machineContextFactory(onboardingAnswers)
   const onboardingMachine = onboardingMachineFactory(machineContext)
@@ -121,8 +121,8 @@ const Onboarding = ({
       questionId,
     } = settingsByQuestion[currentQuestion]
 
-    if (!deadEnd) {
-      postOnboardingAnswer({
+    if (finalStep) {
+      return setLastAnswerSubmited({
         answer,
         others,
         question_id: questionId,
@@ -130,8 +130,13 @@ const Onboarding = ({
       })
     }
 
-    if (finalStep) {
-      return setShowFakeLoader(true)
+    if (!deadEnd) {
+      postOnboardingAnswer({
+        answer,
+        others,
+        question_id: questionId,
+        user_id: userId,
+      })
     }
 
     return sendEvent('NEXT', { answer })
@@ -156,14 +161,16 @@ const Onboarding = ({
   const shouldRedirectToHome = isNil(onboardingAnswers)
     || onboardingAlreadyFinished
 
-  if (shouldRedirectToHome && !showFakeLoader) {
+  if (shouldRedirectToHome && !lastAnswerSubmited) {
     return <Redirect to="/home" />
   }
 
-  if (showFakeLoader) {
+  if (lastAnswerSubmited) {
     return (
       <FakeLoader
-        runAfterLoader={() => push('/home')}
+        runAfterLoader={() => {
+          postOnboardingAnswer(lastAnswerSubmited)
+        }}
         t={t}
       />
     )

--- a/packages/pilot/src/pages/Root.js
+++ b/packages/pilot/src/pages/Root.js
@@ -14,7 +14,6 @@ import {
   pipe,
   startsWith,
   tail,
-  anyPass,
 } from 'ramda'
 
 import { requestLogin as requestLoginAction } from './Account/actions/actions'
@@ -27,11 +26,10 @@ import ChooseDashboard from './ChooseDashboard'
 import LoggedArea from './LoggedArea'
 import Onboarding from './Onboarding/Onboarding'
 import Loader from '../components/Loader'
-import isRecentlyCreatedUser from '../validation/recentCreatedUser'
-import isOnboardingComplete from '../validation/isOnboardingComplete'
 
 import environment from '../environment'
 import { page as appcuesPage } from '../vendor/appcues'
+import { shouldSkipOnboarding } from './EmptyState/reducer'
 
 const mapStateToProps = ({
   account: {
@@ -40,18 +38,13 @@ const mapStateToProps = ({
     sessionId,
     user,
   },
-  welcome: {
-    error: onboardingError,
-    loading: loadingOnboardingAnswers,
-    onboardingAnswers,
-  },
+  welcome,
 }) => ({
   client,
   company,
-  fetchOnboardingAnswersFailed: !!onboardingError,
-  loadingOnboardingAnswers,
-  onboardingAnswers,
+  loadingOnboardingAnswers: welcome.loading,
   sessionId,
+  skipOnboarding: shouldSkipOnboarding({ company, welcome }),
   user,
 })
 
@@ -76,27 +69,6 @@ const shouldSelectDashboard = () => {
   const choiceExpiresAt = localStorage.getItem('dashboardChoiceExpiresAt')
   return moment(choiceExpiresAt).isBefore(moment())
 }
-const isOnboardingSkipped = () => localStorage.getItem('skip-onboarding')
-const userAlreadyTransacted = ({ company }) => company.alreadyTransacted
-const onboardingAnswersError = ({
-  fetchOnboardingAnswersFailed,
-}) => fetchOnboardingAnswersFailed
-const onboardingCompleted = ({
-  onboardingAnswers,
-}) => isOnboardingComplete(onboardingAnswers)
-const longTimeUser = ({
-  company,
-  user,
-}) => !isRecentlyCreatedUser({ company, user })
-
-const skipOnboarding = anyPass([
-  isOnboardingSkipped,
-  onboardingCompleted,
-  userAlreadyTransacted,
-  longTimeUser,
-  onboardingAnswersError,
-])
-
 class Root extends Component {
   componentDidMount () {
     const {
@@ -138,15 +110,14 @@ class Root extends Component {
     const {
       client,
       company,
-      fetchOnboardingAnswersFailed,
       history,
       loadingOnboardingAnswers,
       location: {
         pathname: path,
         search: queryString,
       },
-      onboardingAnswers,
       sessionId,
+      skipOnboarding,
       user,
     } = this.props
 
@@ -200,9 +171,7 @@ class Root extends Component {
       return window.open(`https://dashboard.pagar.me/#login?session_id=${sessionId}&redirect_to=dashboard.home&environment=${environment}`, '_self')
     }
 
-    if (!skipOnboarding({
-      company, fetchOnboardingAnswersFailed, onboardingAnswers, user,
-    })) {
+    if (!skipOnboarding) {
       return <Onboarding />
     }
 
@@ -213,7 +182,6 @@ class Root extends Component {
 Root.propTypes = {
   client: PropTypes.object, // eslint-disable-line
   company: PropTypes.object, // eslint-disable-line
-  fetchOnboardingAnswersFailed: PropTypes.bool.isRequired,
   history: PropTypes.shape({
     listen: PropTypes.func,
     replace: PropTypes.func,
@@ -223,16 +191,15 @@ Root.propTypes = {
     pathname: PropTypes.string,
     search: PropTypes.string,
   }).isRequired,
-  onboardingAnswers: PropTypes.objectOf(PropTypes.string),
   requestLogin: PropTypes.func.isRequired,
   sessionId: PropTypes.string,
+  skipOnboarding: PropTypes.bool.isRequired,
   user: PropTypes.object, // eslint-disable-line
 }
 
 Root.defaultProps = {
   client: null,
   company: null,
-  onboardingAnswers: null,
   sessionId: null,
   user: null,
 }

--- a/packages/pilot/src/validation/recentCreatedCompany.js
+++ b/packages/pilot/src/validation/recentCreatedCompany.js
@@ -5,16 +5,16 @@ import {
   pathOr,
 } from 'ramda'
 
-const userCreatedLessThan30DaysAgo = ({ user }) => {
-  const createdAtDaysDiff = moment().diff(user.date_created, 'days')
+const userCreatedLessThan30DaysAgo = ({ company }) => {
+  const createdAtDaysDiff = moment().diff(company.date_created, 'days')
   return createdAtDaysDiff < 30
 }
 
 const companyNotTransacted = complement(pathOr(true, ['company', 'alreadyTransacted']))
 
-const isRecentlyCreatedUser = anyPass([
+const isRecentlyCreatedCompany = anyPass([
   companyNotTransacted,
   userCreatedLessThan30DaysAgo,
 ])
 
-export default isRecentlyCreatedUser
+export default isRecentlyCreatedCompany


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
Hoje quando um novo usuário entra na pilot demora alguns segundos até que a página do onboarding seja exibida, enquanto isso o empty state é renderizado em tela. Para tornar o carregamento do onboarding mais fluido foram realizadas algumas modificações.

## Checklist
- [x] Alteração do Loader para que ele possa aceitar o modo `opaqueBackground` que esconde os elementos abaixo dele;
- [x] Remover o Onboarding do EmptyState e incluindo a verificação no Root, diminuindo o número de redirecionamento até ele;
- [x] Não esperar esperar o onboardingAnswers para decidir se vai mostrar o onboarding caso seja um usuário antigo ou que tenha escolhido pular essa etapa; 

## Issues linkadas
[CRED-150](https://mundipagg.atlassian.net/browse/CRED-150)

## Como testar?
Logar na pilot com um usuário criado recentemente.
