### PR TITLE
EXP-148: Padroniza verificação do tipo de company

### DIFF
--- a/packages/pilot/src/containers/Balance/index.js
+++ b/packages/pilot/src/containers/Balance/index.js
@@ -13,7 +13,6 @@ import {
   path,
   pipe,
   prop,
-  propEq,
   propSatisfies,
   take,
   when,
@@ -54,6 +53,7 @@ import dateInputPresets from '../../models/dateSelectorPresets'
 import DetailsHead from '../../components/DetailsHead'
 import PendingAnticipations from '../../components/PendingAnticipations'
 import BalanceOperations from '../BalanceOperations'
+import isPaymentLink from '../../validation/isPaymentLink'
 
 import style from './style.css'
 
@@ -114,8 +114,6 @@ const getSelectedPreset = (end, start) => {
   }
   return 'period'
 }
-
-const isPaymentLink = propEq('type', 'payment_link_app')
 
 class Balance extends Component {
   constructor (props) {
@@ -487,7 +485,8 @@ class Balance extends Component {
 
     const { ted } = getTransfersPricing(company)
 
-    const balanceGridCol = isPaymentLink(company) ? 6 : 4
+    const isCompanyPaymentLink = isPaymentLink(company)
+    const balanceGridCol = isCompanyPaymentLink ? 6 : 4
 
     return (
       <Fragment>
@@ -557,7 +556,7 @@ class Balance extends Component {
               <Card>
                 <BalanceTotalDisplay
                   action={
-                    isNil(onAnticipationClick) || isPaymentLink(company)
+                    isNil(onAnticipationClick) || isCompanyPaymentLink
                       ? null
                       : anticipationAction
                   }
@@ -573,7 +572,7 @@ class Balance extends Component {
                   //   || anticipationError
                   //   || available < MINIMUM_API_VALUE
                   // }
-                  detail={!isPaymentLink(company) && (
+                  detail={!isCompanyPaymentLink && (
                     <span>
                       {t('pages.balance.anticipation_call')}
                     </span>
@@ -583,7 +582,7 @@ class Balance extends Component {
                 />
               </Card>
             </Col>
-            {!isPaymentLink(company) && (
+            {!isCompanyPaymentLink && (
               <Col
                 desk={4}
                 palm={12}

--- a/packages/pilot/src/containers/Header/index.js
+++ b/packages/pilot/src/containers/Header/index.js
@@ -30,6 +30,7 @@ import environment, {
 } from '../../environment'
 
 import style from './style.css'
+import isPaymentLink from '../../validation/isPaymentLink'
 
 const getEnvironmentUrl = () => (
   environment === 'test'
@@ -40,42 +41,46 @@ const getEnvironmentUrl = () => (
 const renderEnvironmentButton = ({
   companyType,
   t,
-}) => (
-  <Popover
-    content={(
-      <PopoverContent>
-        <small>
-          {t(`header.environment.text_${environment}`)}&nbsp;
-          <a href={getEnvironmentUrl()}>
-            {t('header.environment.text_action')}
-          </a>.
-        </small>
-      </PopoverContent>
-    )}
-    placement="bottomEnd"
-  >
-    {environment === 'test' && companyType !== 'payment_link_app'
-      && (
-        <small className={style.testEnvironmentLabel}>
-          {t('header.environment.test_environment')}
-        </small>
-      )
-    }
-    {
-      companyType !== 'payment_link_app'
-      && (
-        <Button
-          fill="clean"
-          icon={
-            environment === 'test'
-              ? <IconTestAmbientOn />
-              : <IconTestAmbientOff />
-          }
-        />
-      )
-    }
-  </Popover>
-)
+}) => {
+  const isCompanyPaymentLink = isPaymentLink(companyType)
+
+  return (
+    <Popover
+      content={(
+        <PopoverContent>
+          <small>
+            {t(`header.environment.text_${environment}`)}&nbsp;
+            <a href={getEnvironmentUrl()}>
+              {t('header.environment.text_action')}
+            </a>.
+          </small>
+        </PopoverContent>
+      )}
+      placement="bottomEnd"
+    >
+      {environment === 'test' && !isCompanyPaymentLink
+        && (
+          <small className={style.testEnvironmentLabel}>
+            {t('header.environment.test_environment')}
+          </small>
+        )
+      }
+      {
+        !isCompanyPaymentLink
+        && (
+          <Button
+            fill="clean"
+            icon={
+              environment === 'test'
+                ? <IconTestAmbientOn />
+                : <IconTestAmbientOff />
+            }
+          />
+        )
+      }
+    </Popover>
+  )
+}
 
 const HeaderContainer = ({
   companyType,

--- a/packages/pilot/src/containers/Settings/Company/index.js
+++ b/packages/pilot/src/containers/Settings/Company/index.js
@@ -12,6 +12,8 @@ import ProductInfoTab from './ProductInfoTab'
 import RegisterInfoTab from './RegisterInfoTab'
 import TeamInfoTab from './TeamInfoTab'
 
+import isPaymentLink from '../../../validation/isPaymentLink'
+
 class CompanySettings extends Component {
   constructor (props) {
     super(props)
@@ -81,7 +83,7 @@ class CompanySettings extends Component {
           >
             <TabItem text={t('pages.settings.company.tab.general')} />
             <TabItem text={t('pages.settings.company.tab.products')} />
-            {type !== 'payment_link_app'
+            {!isPaymentLink(type)
               ? <TabItem text={t('pages.settings.company.tab.team')} />
               : <></>
             }

--- a/packages/pilot/src/containers/Sidebar/index.js
+++ b/packages/pilot/src/containers/Sidebar/index.js
@@ -30,6 +30,7 @@ import SidebarSections from '../../components/SidebarSections'
 import SidebarSummary from '../../components/SidebarSummary'
 import formatDecimalCurrency from '../../formatters/decimalCurrency'
 import environment from '../../environment'
+import isPaymentLink from '../../validation/isPaymentLink'
 
 const MINIMUM_API_VALUE = 100
 
@@ -184,7 +185,7 @@ class SidebarContainer extends React.Component {
             />
           ))}
         </SidebarLinks>
-        {!collapsed && companyType !== 'payment_link_app'
+        {!collapsed && !isPaymentLink(companyType)
           && (
             <Flexbox
               className={style.backToOldVersion}

--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -50,6 +50,8 @@ import {
   inactiveCompanyLogin,
 } from '../../../vendor/googleTagManager'
 
+import isPaymentLink from '../../../validation/isPaymentLink'
+
 const isActiveCompany = propEq('status', 'active')
 const isSelfRegister = propEq('type', 'self_register')
 const isPendingRiskAnalysis = propEq('status', 'pending_risk_analysis')
@@ -249,7 +251,7 @@ const companyEpic = (action$, state$) => action$.pipe(
     ])
 
     if (status === 'active') {
-      if (type === 'payment_link_app') {
+      if (isPaymentLink(type)) {
         paymentLinkCompanyLogin()
       } else {
         activeCompanyLogin()

--- a/packages/pilot/src/pages/CompanySettings/index.js
+++ b/packages/pilot/src/pages/CompanySettings/index.js
@@ -25,6 +25,7 @@ import { translate } from 'react-i18next'
 import { requestLogout } from '../Account/actions/actions'
 import CompanySettings from '../../containers/Settings/Company'
 import environment from '../../environment'
+import isPaymentLink from '../../validation/isPaymentLink'
 
 import { selectCompanyFees } from '../Account/actions/reducer'
 
@@ -141,7 +142,6 @@ const defaultBankAccountErrorsState = {
 }
 
 const userIsReadOnly = propEq('permission', 'read_only')
-const hiddenApiKey = propEq('type', 'payment_link_app')
 
 class CompanySettingsPage extends React.Component {
   constructor (props) {
@@ -618,7 +618,7 @@ class CompanySettingsPage extends React.Component {
         general={general}
         handleCreateUser={this.handleCreateUser}
         handleDeleteUser={this.handleDeleteUser}
-        hiddenApiKey={hiddenApiKey(company)}
+        hiddenApiKey={isPaymentLink(company)}
         isMDRzao={isMDRzao}
         managingPartner={managingPartner}
         onBankAccountCancel={this.handleAccountCancel}

--- a/packages/pilot/src/pages/EmptyState/EmptyState.js
+++ b/packages/pilot/src/pages/EmptyState/EmptyState.js
@@ -20,13 +20,13 @@ import {
   requestOnboardingAnswers as requestOnboardingAnswersAction,
 } from './actions'
 import isOnboardingComplete from '../../validation/isOnboardingComplete'
+import isPaymentLink from '../../validation/isPaymentLink'
 
 import { selectCompanyFees } from '../Account/actions/reducer'
 
 const getUserName = pipe(prop('name'), split(' '), head)
 
 const hasAdminPermission = propEq('permission', 'admin')
-const isPaymentLink = propEq('type', 'payment_link_app')
 
 const getAccessKeys = applySpec({
   apiKey: path(['api_key', environment]),

--- a/packages/pilot/src/validation/isPaymentLink.js
+++ b/packages/pilot/src/validation/isPaymentLink.js
@@ -1,0 +1,12 @@
+import {
+  either,
+  equals,
+  propEq,
+} from 'ramda'
+
+const isPaymentLink = either(
+  propEq('type', 'payment_link_app'),
+  equals('payment_link_app')
+)
+
+export default isPaymentLink


### PR DESCRIPTION
## Contexto
Precisamos padronizar a verificação de company do tipo `payment_link_app`. Esse PR refatora todos os arquivos alterados pelos PRs que checavam o tipo da company.

## Checklist
PRs alterados:
 - [x] [EXP-95 - Remove onboarding company payment-link-app](https://github.com/pagarme/pilot/pull/1687)
 - [x] [EXP-97 -  hidden api key to customers of payment link](https://github.com/pagarme/pilot/pull/1668)
 - [x] [EXP-99 Add/chat link me](https://github.com/pagarme/pilot/pull/1669)
 - [x] [EXP-100 payment_link_app: removing buttons](https://github.com/pagarme/pilot/pull/1667)
 - [x] [EXP-101 - Melhorar experiencia da tela de extrato para clientes link.me, como ocultar elementos de antecipação spot](https://github.com/pagarme/pilot/pull/1683)
 - [x] [EXP-102 - Esconder a aba equipe existente na pilot para clientes link.me ](https://github.com/pagarme/pilot/pull/1681)

## Issues linkadas
- [x] Resolves [EXP-148](https://mundipagg.atlassian.net/browse/EXP-148)

## Como testar?
**Obs.:** Como todos os fluxos já foram validados anteriormente, devemos verificar apenas se nada foi alterado:

#### EXP-95
Não mostrar onboarding para companies link

#### EXP-97
Logar com uma company normal e verificar se está mostrando api_key e versionamento da api.
Logar com uma company `payment_link_app` e checar se os campos estão ocultos.

#### EXP-99
Acessar pelo [link de debug](https://www.googletagmanager.com/start_preview/gtm?uiv2&id=GTM-MMGHSNN&check_preview_status=1&gtm_auth=mtpUyy_l-sQ4X2XQvsZDRw&gtm_preview=env-5&gtm_debug=x&url=http%3A%2F%2Flocalhost%3A3000%2F) do gtm no chrome
Verificar se o painel de debug do gtm aparece na parte inferior da tela conforme imagem abaixo
![image](https://user-images.githubusercontent.com/46823713/88218273-3227f080-cc36-11ea-8496-1aa65b0ad8da.png)
Efetuar login com uma company com o tipo diferente de payment_link_app
Verificar se o evento activeCompanyLogin foi disparado
Efetuar login com uma company do tipo payment_link_app
Verificar se o evento paymentLinkCompanyLogin foi disparado

#### EXP-100
Logar com company `payment_link_app`
Não deverá ser mostrado no header a informação do ambiente que vc está
Não deverá ser mostrado no site o botão para voltar pra dash antiga

#### EXP-101
Entre na página Extrato com uma company `payment_link_app`
Entre na página Extrato com uma company de qualquer outro tipo

#### EXP-102
Entre em uma company na pilot SEM o tipo payment_link_app e veja se aparece a tab Equipes na página de Configurações
Entre em uma company na pilot COM o tipo payment_link_app e veja se desaparece a tab Equipes na página de Configurações
