### PR TITLE
EXP-173 transaction: add customer name fallback in list

### DIFF
--- a/packages/pilot/src/containers/TransactionsList/tableColumns.js
+++ b/packages/pilot/src/containers/TransactionsList/tableColumns.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  either,
   path,
   pick,
   pipe,
@@ -18,8 +19,13 @@ const convertPaymentValue = property => pipe(
   formatCurrency
 )
 
+const getCustomerName = either(
+  path(['customer', 'name']),
+  path(['card', 'holder_name'])
+)
+
 const applyTruncateCustomerName = (item) => {
-  const value = path(['customer', 'name'], item)
+  const value = getCustomerName(item)
 
   return value
     ? (


### PR DESCRIPTION
Percebemos que a versão 2017-07-17 permite transações sem customer. Hoje a dashboard atual usa como fallback nesse caso para exibição de nome o card_holder_name na listagem de transação.Implementar o comportamento semelhante para que os usuários que hoje operam dessa forma consigam usar a pilot sem problema.

Este pr implementa o comportamento semelhante para a listagem de transações da pilot

### como testar
- baixar a branch add/customer-name-fallaback
- criar uma transação na versão de api 2017-07-17 sem informar os campos relacionados a customer no body
- abrir a listagem de transações rodando a pilot localmente
- o campo nome deve ter sido preenchido com o valor do card_holder_name