### PR TITLE
EXP-186: Corrige erro no extrato para novos clientes Link.me

### DIFF
--- a/packages/cockpit/src/balance/data/index.js
+++ b/packages/cockpit/src/balance/data/index.js
@@ -15,12 +15,18 @@ const getValidStatus = when(
 
 const ignoredProps = ['status', 'recipientId']
 
-const data = client => (recipientId, query = {}) => Promise.props({
+const data = client => (
+  recipientId,
+  shouldRequestAnticipations,
+  query = {}
+) => Promise.props({
   balance: client.balance.find({ recipientId }),
-  bulk_anticipations_pending: client.bulkAnticipations.find({
-    recipientId,
-    status: 'pending',
-  }),
+  bulk_anticipations_pending: shouldRequestAnticipations
+    ? client.bulkAnticipations.find({
+      recipientId,
+      status: 'pending',
+    })
+    : Promise.resolve([]),
   recipient: client.recipients.find({ id: recipientId }),
   withdrawal: client.transfers.limits({ recipient_id: recipientId }),
 }).then(buildResult({

--- a/packages/pilot/src/containers/RecipientDetails/index.js
+++ b/packages/pilot/src/containers/RecipientDetails/index.js
@@ -118,7 +118,7 @@ class RecipientDetails extends Component {
 
 /* eslint-disable react/forbid-foreign-prop-types */
 const infoProps = omit(['t'], Information.propTypes)
-const configProps = omit(['t'], Configuration.propTypes)
+const configProps = omit(['capabilities', 't'], Configuration.propTypes)
 const balanceProps = omit(['t'], Balance.propTypes)
 /* eslint-enable react/forbid-foreign-prop-types */
 

--- a/packages/pilot/src/pages/Balance/Balance.js
+++ b/packages/pilot/src/pages/Balance/Balance.js
@@ -606,9 +606,14 @@ class Balance extends Component {
   }
 
   requestData (id, searchQuery) {
-    const { client, onRequestBalance } = this.props
+    const { client, company, onRequestBalance } = this.props
+    const shouldRequestBulkAnticipation = pathEq(['capabilities', 'allow_transaction_anticipation'], false, company)
     onRequestBalance({ searchQuery })
-    const dataPromise = client.balance.data(id, searchQuery)
+    const dataPromise = client.balance.data(
+      id,
+      shouldRequestBulkAnticipation,
+      searchQuery
+    )
     const totalPromise = client.balance.total(id, searchQuery)
     const operationsPromise = client.balance
       .operations({ recipientId: id, ...searchQuery })

--- a/packages/pilot/src/pages/Recipients/Detail/index.js
+++ b/packages/pilot/src/pages/Recipients/Detail/index.js
@@ -16,6 +16,7 @@ import {
   compose,
   lensPath,
   mergeLeft,
+  pathEq,
   pipe,
   propEq,
   reject,
@@ -38,14 +39,16 @@ const mapStateToProps = (state = {}) => {
       anticipation_config: {
         config_anticipation_params: canConfigureAnticipation,
       },
+      capabilities,
     } = {
       anticipation_config: {
         config_anticipation_params: false,
       },
+      capabilities: {},
     },
   } = account || {}
 
-  return { canConfigureAnticipation, client }
+  return { canConfigureAnticipation, capabilities, client }
 }
 
 const enhanced = compose(
@@ -554,7 +557,12 @@ class DetailRecipientPage extends Component {
       selectedItemsPerPage,
       timeframe,
     } = this.state
-    const { client, match } = this.props
+    const {
+      capabilities,
+      client,
+      match,
+    } = this.props
+
     const { id } = match.params
     const query = {
       count: selectedItemsPerPage,
@@ -563,7 +571,13 @@ class DetailRecipientPage extends Component {
       timeframe,
     }
 
-    const getRecipientData = client.balance.data(id, query)
+    const shouldRequestBulkAnticipation = pathEq(['allow_transaction_anticipation'], false, capabilities)
+
+    const getRecipientData = client.balance.data(
+      id,
+      shouldRequestBulkAnticipation,
+      query
+    )
 
     return getRecipientData
   }
@@ -820,6 +834,9 @@ class DetailRecipientPage extends Component {
 
 DetailRecipientPage.propTypes = {
   canConfigureAnticipation: PropTypes.bool.isRequired,
+  capabilities: PropTypes.shape({
+    allow_transaction_anticipation: PropTypes.bool,
+  }).isRequired,
   client: PropTypes.shape({
     bulkAnticipations: PropTypes.shape({
       cancel: PropTypes.func.isRequired,


### PR DESCRIPTION
## Contexto
Após testarmos a release do linkme, descobrimos que o extrato estava dando erro para novos clientes linkme.
![image](https://user-images.githubusercontent.com/46823713/88946627-dd076280-d265-11ea-9ef4-cc3a90c70b7b.png)
Esse PR refatora a request de antecipação pendente para ser feita apenas por companies que não possuem antecipação compulsória.

## Checklist
- [x] Refatora a request de antecipação pendente.
- [x] Atualiza as telas de Recipient e Balance, passando a capability para a request.

## Issues linkadas
- [x] Resolves [EXP-186](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=185&projectKey=EXP&modal=detail&selectedIssue=EXP-186)

## Como testar?
- Crie uma company nova no linkme
- Acesse a branch `fix/balance-error`
- Rode `yarn` na pasta raiz do projeto
- Em Extrato
- Em `recipients` acesse o detalhe do recebedor
- Verifique se o erro `Method not allowed` não é mais mostrado.