### PR TITLE
EXP-200: Remove redirecionamento para escolha de dashboard de companies paymentLink

### DIFF
--- a/packages/pilot/src/pages/Root.js
+++ b/packages/pilot/src/pages/Root.js
@@ -19,6 +19,8 @@ import {
 import { requestLogin as requestLoginAction } from './Account/actions/actions'
 import { inactiveCompanyLogin } from '../vendor/googleTagManager'
 
+import isPaymentLink from '../validation/isPaymentLink'
+
 import Account from './Account'
 import ChooseDashboard from './ChooseDashboard'
 import LoggedArea from './LoggedArea'
@@ -136,7 +138,7 @@ class Root extends Component {
       return null
     }
 
-    if (!user && !company) {
+    if (!user || !company) {
       return null
     }
 
@@ -144,7 +146,11 @@ class Root extends Component {
       return <Route path="/choose-dashboard" component={ChooseDashboard} />
     }
 
-    if (user && shouldSelectDashboard()) {
+    if (
+      !isPaymentLink(company)
+      && user
+      && shouldSelectDashboard()
+    ) {
       history.replace('/choose-dashboard')
       return null
     }


### PR DESCRIPTION
## Contexto
Hoje ao logar com uma company na pilot estamos mostrando uma tela onde pedimos para o usuário escolher qual dashboard deseja usar:

![image](https://user-images.githubusercontent.com/46823713/89469966-025a0c00-d751-11ea-8912-de76610950cd.png)

Precisamos impedir o redirecionamento de clientes linkme para essa rota.

## Checklist
- [x] Adiciona verificação para não redirecionar companies `payment_link_app` para a rota de escolha de dashboard.

## Issues linkadas
- [x] Resolves [EXP-200](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=185&modal=detail&selectedIssue=EXP-200)

## Como testar?
- Acesse a branch `remove/redirect`
- Entre com uma company do tipo `payment_link_app`
> Pode ser necessário comentar ou excluir a variável `recaptchaToken` daqui: https://github.com/pagarme/pilot/blob/b1803c1b9a5b3f12b319cd54103c36935650cb97/packages/pilot/src/containers/Account/LoginForm/index.js#L70

- Não deve ser mostrado a escolha de dashboard
