### PR TITLE
EXP-203 - Corrige capability de captura de transações

### DIFF
--- a/packages/cockpit/src/transactions/details/isCapturable.js
+++ b/packages/cockpit/src/transactions/details/isCapturable.js
@@ -1,4 +1,5 @@
 import {
+  both,
   ifElse,
   propEq,
 } from 'ramda'
@@ -14,7 +15,7 @@ const isTokenValid = (transaction) => {
 
 const isCapturable = ifElse(
   isFromCheckout,
-  isAuthorized && isTokenValid,
+  both(isAuthorized, isTokenValid),
   isAuthorized
 )
 


### PR DESCRIPTION
## Contexto
Transações criadas com encryption key tem até 5 horas para serem capturadas. Este PR corrige a validação que fazemos no cockpit quanto à isto

## Checklist
- [x] Refatora validação de capturable para transações criadas pelo Checkout (encryption key)

## Como testar?
1. Crie uma transação recusada com encryption key e verifique se é capturável (basta gerar uma recusa em um link de pagamento)