### PR TITLE
chore: refactor avoid recaptcha use last token

### DIFF
--- a/packages/pilot/src/containers/Account/LoginForm/index.js
+++ b/packages/pilot/src/containers/Account/LoginForm/index.js
@@ -53,6 +53,8 @@ const LoginForm = ({
   const handleLoginActionOnClick = (e) => {
     e.preventDefault()
 
+    recaptchaRef.current.reset()
+
     const result = validate()
     if (result) {
       setFormErrors(result)


### PR DESCRIPTION
## Contexto

Esse PR força o recaptcha a gerar um novo token em cada requisição em /sessions.

Isto é necessário pois um token só pode ser usado para validar o recaptcha uma vez, caso seja, utilizado duas vezes o recaptcha irá dizer que é um cliente invalido.

## Checklist
- [ ] Força o recaptcha a gerar um novo token em cada requisição em /sessions.

## Issues linkadas
- [ ] https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=192&projectKey=CRED&modal=detail&selectedIssue=CRED-232
