### PR TITLE
chore: update header environmnets btn translation

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -161,9 +161,9 @@
       "logout": "Encerrar sessão"
     },
     "environment": {
-      "text_action_live": "clique aqui",
+      "text_action_live": "ambiente de testes",
       "text_action_test": "Mudar para live",
-      "text_live": "Você está no ambiente Live. Para ir para o ambiente Test",
+      "text_live": "Você está no ambiente live. Para testar sua integração, faça isso no",
       "text_test_1": "Você está no ambiente de testes, operações realizadas neste ambiente",
       "text_test_2": "não geram pagamentos reais."
     },

--- a/packages/pilot/src/containers/Header/index.js
+++ b/packages/pilot/src/containers/Header/index.js
@@ -57,9 +57,9 @@ const renderEnvironmentButton = ({
     content={(
       <PopoverContent>
         <small>
-          {t(`header.environment.text_${environment}`)}&nbsp;
+          {t('header.environment.text_live')}&nbsp;
           <a href={getEnvironmentUrl()}>
-            {t('header.environment.text_action')}
+            {t('header.environment.text_action_live')}
           </a>.
         </small>
       </PopoverContent>
@@ -128,6 +128,7 @@ const HeaderContainer = ({
 
         {
           companyType
+            && environment === 'live'
             && !isPaymentLink(companyType)
             && renderEnvironmentButton({ t })
         }


### PR DESCRIPTION
## Contexto

Realiza o ajuste das traduções no botão enviroment da nova dashboard.

![image](https://user-images.githubusercontent.com/13531067/90134227-39c74a80-dd47-11ea-9ec6-ef78423093f1.png)

Também esconde para que esse botão só apareça no ambiente de live.

Essas traduções foram removidas no PR https://github.com/pagarme/pilot/pull/1697/files, estou ajustando elas novamente.

## Checklist
- [ ] Realiza o ajuste das traduções no botão enviroment da nova dashboard.
- [ ] Esconda para que esse botão só apareça no ambiente de live.

## Issues linkadas
- [ ] [CRED-237](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=186&projectKey=CRED&modal=detail&selectedIssue=CRED-237)
