### PR TITLE
EXP-234 - Corrige exibição de recebíveis no Extrato

### DIFF
--- a/packages/cockpit/src/balance/operations/buildRequest.js
+++ b/packages/cockpit/src/balance/operations/buildRequest.js
@@ -42,7 +42,7 @@ const buildPayablesQuery = ({
     `>=${moment(start).startOf('day').valueOf()}`,
     `<=${moment(end).endOf('day').valueOf()}`,
   ],
-  status: ['waiting_funds', 'prepaid'],
+  status: 'waiting_funds',
 })
 
 const buildPayablesRequest = curry((client, query) => {


### PR DESCRIPTION
## Contexto
Atualmente a pilot busca por dois status simultaneamente em nossa rota `/payables`, porém, após migração ao Atlas esse tipo de filtro simultâneo deixou de funcionar por não ser documentado antes. A pilot buscava payables dos seguintes status:
- `prepaid` - Payables que estão no fluxo de alguma task serem processados
- `waiting_funds` - Payables que ainda serão processados

Como fazer duas requests para buscar ambos os status quebraria nossa paginação (por não conseguirmos garantir 15 ou mais itens por request), neste PR ajusto o extrato futuro para buscar somente payables `waiting_funds`

## Checklist
- [x] Refatora request em `/payables` para buscar somente payables com status `waiting_funds`

## Como testar?
1. Acesse a página de extrato e clique em "A Receber", devem aparecer linhas na tabela caso tenha recebíveis disponíveis em sua conta. Note que a ordenação das linhas é feita primeiramente por `id`, comportamento que não foi alterado.