### PR TITLE
Release - Perfil de vendedor

### DIFF
--- a/packages/cockpit/src/balance/operations/operations.test.js
+++ b/packages/cockpit/src/balance/operations/operations.test.js
@@ -11,11 +11,6 @@ import operations, {
   isRefundOrChargeBack,
   isRefundReversal,
   isTedTransfer,
-  isGatewayFeeCollection,
-  isAdjustmentFeeCollection,
-  gatewayFeeCollectionOutgoing,
-  adjustmentFeeCollectionOutgoing,
-  adjustmentFeeCollectionOutcoming,
   refundOrChargeBackOutcoming,
   refundOrChargeBackOutgoing,
   tedTransferOutgoing,
@@ -280,38 +275,6 @@ describe('Operations table data', () => {
       expect(outcoming).toEqual(expected)
     })
 
-    it('should validate if it is a gateway fee collection', () => {
-      const isGateway = isGatewayFeeCollection({
-        type: 'fee_collection',
-        movement_object: {
-          movement_object: {
-            type: 'gateway',
-          },
-        },
-      })
-
-      expect(isGateway).toBe(true)
-    })
-
-    it('should build a correct gateway collection outgoing', () => {
-      const outgoing = gatewayFeeCollectionOutgoing({
-        type: 'fee_collection',
-        movement_object: {
-          amount: -6755,
-          movement_object: {
-            type: 'gateway',
-          },
-        },
-      })
-
-      const expected = [{
-        amount: -6755,
-        type: 'gateway',
-      }]
-
-      expect(outgoing).toEqual(expected)
-    })
-
     it('should validate if it is a refund reversal', () => {
       const result = isRefundReversal({
         type: 'payable',
@@ -321,53 +284,6 @@ describe('Operations table data', () => {
       })
 
       expect(result).toBe(true)
-    })
-
-    it('should validate if it is a fee_adjustment fee collection', () => {
-      const isFeeAdjustment = isAdjustmentFeeCollection({
-        type: 'fee_collection',
-        movement_object: {
-          type: 'fee_adjustment',
-        },
-      })
-
-      expect(isFeeAdjustment).toBe(true)
-    })
-
-    it('should build a correct fee_adjustment outgoing', () => {
-      const outgoing = adjustmentFeeCollectionOutgoing({
-        amount: -10000,
-        type: 'fee_collection',
-        movement_object: {
-          amount: -10000,
-          type: 'fee_adjustment',
-        },
-      })
-
-      const expected = [{
-        amount: -10000,
-        type: 'fee_adjustment',
-      }]
-
-      expect(outgoing).toEqual(expected)
-    })
-
-    it('should build a correct fee_adjument outcoming', () => {
-      const outcoming = adjustmentFeeCollectionOutcoming({
-        amount: 10000,
-        type: 'fee_collection',
-        movement_object: {
-          amount: 10000,
-          type: 'fee_adjustment',
-        },
-      })
-
-      const expected = [{
-        amount: 10000,
-        type: 'fee_adjustment',
-      }]
-
-      expect(outcoming).toEqual(expected)
     })
 
     it('should validate if it is a chargeback_refund', () => {
@@ -417,6 +333,66 @@ describe('Operations table data', () => {
       }]
 
       expect(outgoing).toEqual(expected)
+    })
+
+    describe('When balanceOperation is of type fee_collection', () => {
+      describe('and has negative amount', () => {
+        const movementObject = {
+          amount: -5000,
+          type: 'fee_collection',
+        }
+
+        it('should return zero as outcoming', () => {
+          const outcoming = buildOutcoming(movementObject)
+
+          const expected = [{
+            amount: 0,
+            type: 'payable',
+          }]
+
+          expect(outcoming).toEqual(expected)
+        })
+
+        it('should return the expected outgoing', () => {
+          const outgoing = buildOutgoing(movementObject)
+
+          const expected = [{
+            amount: -5000,
+            type: 'fee_collection',
+          }]
+
+          expect(outgoing).toEqual(expected)
+        })
+      })
+
+      describe('and has positive amount', () => {
+        const movementObject = {
+          amount: 5000,
+          type: 'fee_collection',
+        }
+
+        it('should return zero as outgoing', () => {
+          const outgoing = buildOutgoing(movementObject)
+
+          const expected = [{
+            amount: 0,
+            type: 'payable',
+          }]
+
+          expect(outgoing).toEqual(expected)
+        })
+
+        it('should return the expected outcoming', () => {
+          const outcoming = buildOutcoming(movementObject)
+
+          const expected = [{
+            amount: 5000,
+            type: 'fee_collection',
+          }]
+
+          expect(outcoming).toEqual(expected)
+        })
+      })
     })
   })
 })

--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -633,6 +633,7 @@
         "admin": "Administrador",
         "read_only": "Somente leitura",
         "read_write": "Leitura e escrita",
+        "seller": "Vendedor",
         "errors": {
           "insufficient_permission": {
             "message": "Permissão insuficiente para realizar esta operação",

--- a/packages/pilot/src/components/Operations/operationsTableColumns.js
+++ b/packages/pilot/src/components/Operations/operationsTableColumns.js
@@ -23,6 +23,7 @@ import {
   Flexbox,
   Spacing,
   Tooltip,
+  Truncate,
 } from 'former-kit'
 import IconAnticipation from 'emblematic-icons/svg/Undo24.svg'
 import HelpInfo from 'emblematic-icons/svg/Help32.svg'
@@ -152,7 +153,7 @@ const renderCreditTransferStatus = (
 const renderFeeCollection = (type, description) => {
   if (type === 'fee_collection' && description) {
     return (
-      <span>{description}</span>
+      <Truncate text={description} />
     )
   }
 

--- a/packages/pilot/src/components/SidebarSummary/index.js
+++ b/packages/pilot/src/components/SidebarSummary/index.js
@@ -19,14 +19,15 @@ const SidebarSummary = ({
       [style.expanded]: !collapsed,
     })}
   >
+    <span className={style.title}>
+      {title}
+    </span>
     <button
-      className={style.title}
+      className={style.button}
       onClick={onClick}
       role="link"
       type="button"
     >
-      {title}
-
       {subtitle
         && (
           <span className={style.subtitle}>

--- a/packages/pilot/src/components/SidebarSummary/style.css
+++ b/packages/pilot/src/components/SidebarSummary/style.css
@@ -21,9 +21,12 @@
     color: var(--color-birdperson-gray-500);
     display: block;
     font-size: 14px;
-    outline: none;
     text-align: left;
     width: 100%;
+  }
+
+  & .button {
+    outline: none;
   }
 
   & .subtitle {

--- a/packages/pilot/src/containers/Header/index.js
+++ b/packages/pilot/src/containers/Header/index.js
@@ -31,6 +31,7 @@ import environment, {
 
 import style from './style.css'
 import isPaymentLink from '../../validation/isPaymentLink'
+import getPermission from '../../utils/helpers/getPermission'
 
 const getEnvironmentUrl = () => (
   environment === 'test'
@@ -74,7 +75,7 @@ const renderEnvironmentButton = ({
 )
 
 const HeaderContainer = ({
-  companyType,
+  company,
   onBack,
   onBackToOldVersion,
   onLogout,
@@ -85,6 +86,8 @@ const HeaderContainer = ({
   t,
   user,
 }) => {
+  const companyType = company.type
+
   const items = isPaymentLink(companyType)
     ? [
       { action: onSettings, title: t('header.account.settings') },
@@ -161,7 +164,7 @@ const HeaderContainer = ({
                 {user.name}
               </strong>
               <small>
-                {t(`models.user.permission.${user.permission}`)}
+                { getPermission(user.permission, company, t) }
               </small>
             </PopoverContent>
             <PopoverMenu
@@ -179,7 +182,9 @@ renderEnvironmentButton.propTypes = {
 }
 
 HeaderContainer.propTypes = {
-  companyType: PropTypes.string,
+  company: PropTypes.shape({
+    type: PropTypes.string,
+  }),
   onBack: PropTypes.func.isRequired,
   onBackToOldVersion: PropTypes.func.isRequired,
   onLogout: PropTypes.func.isRequired,
@@ -200,7 +205,7 @@ HeaderContainer.propTypes = {
 }
 
 HeaderContainer.defaultProps = {
-  companyType: '',
+  company: {},
 }
 
 export default HeaderContainer

--- a/packages/pilot/src/containers/Settings/Company/TeamInfoTab/TeamManagement/AddNewUserModal.js
+++ b/packages/pilot/src/containers/Settings/Company/TeamInfoTab/TeamManagement/AddNewUserModal.js
@@ -16,6 +16,7 @@ import IconInfo from 'emblematic-icons/svg/InfoCircle32.svg'
 import Close from 'emblematic-icons/svg/ClearClose32.svg'
 
 import emailValidation from '../../../../../validation/email'
+import isPaymentLink from '../../../../../validation/isPaymentLink'
 
 const isEmail = t => emailValidation(t('validations.isEmail'))
 const required = t => value => (
@@ -23,20 +24,37 @@ const required = t => value => (
     ? null
     : t('pages.settings.user.card.access.field_required')
 )
-const permissions = [
-  {
-    name: 'Administrador',
-    value: 'admin',
-  },
-  {
-    name: 'Apenas leitura',
-    value: 'read_only',
-  },
-  {
-    name: 'Leitura e escrita',
-    value: 'read_write',
-  },
-]
+const getPermissionList = (company) => {
+  const permissionsList = [
+    'admin',
+    'read_only',
+  ]
+  const newArrayValue = isPaymentLink(company)
+    ? 'seller'
+    : 'read_write'
+
+  return [
+    ...permissionsList,
+    newArrayValue,
+  ]
+}
+
+const getValue = (value) => {
+  if (value === 'seller') {
+    return 'read_write'
+  }
+
+  return value
+}
+
+const getPermissionValues = (permissionsList, t) => (
+  permissionsList.map(item => (
+    {
+      name: t(`models.user.permission.${item}`),
+      value: getValue(item),
+    }
+  ))
+)
 
 class AddNewUserModal extends React.Component {
   constructor (props) {
@@ -63,6 +81,14 @@ class AddNewUserModal extends React.Component {
         },
       })
     }
+  }
+
+  getPermissions () {
+    const { company, t } = this.props
+    const permissionsList = getPermissionList(company)
+    const permissionsValues = getPermissionValues(permissionsList, t)
+
+    return permissionsValues
   }
 
   handleFormSubmit (data, errors) {
@@ -138,7 +164,7 @@ class AddNewUserModal extends React.Component {
             </p>
 
             <RadioGroup
-              options={permissions}
+              options={this.getPermissions()}
               name="permission"
             />
 
@@ -192,6 +218,9 @@ class AddNewUserModal extends React.Component {
 }
 
 AddNewUserModal.propTypes = {
+  company: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+  }).isRequired,
   handleCloseModal: PropTypes.func.isRequired,
   handleCreateUser: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,

--- a/packages/pilot/src/containers/Settings/Company/TeamInfoTab/TeamManagement/UserTable.js
+++ b/packages/pilot/src/containers/Settings/Company/TeamInfoTab/TeamManagement/UserTable.js
@@ -19,6 +19,7 @@ import {
 
 import IconAdd from 'emblematic-icons/svg/Trash24.svg'
 import RemoveUserModal from './RemoveUserModal'
+import getPermission from '../../../../../utils/helpers/getPermission'
 
 const isAscending = equals('ascending')
 
@@ -71,7 +72,7 @@ class UserTable extends React.Component {
   }
 
   getColumns () {
-    const { t } = this.props
+    const { company, t } = this.props
 
     return [
       {
@@ -97,7 +98,11 @@ class UserTable extends React.Component {
       {
         accessor: ['role'],
         orderable: true,
-        renderer: user => t(`models.user.permission.${user.role}`),
+        renderer: user => getPermission(
+          user.role,
+          company,
+          t
+        ),
         title: 'Permissão',
       },
       { accessor: ['date_created'], orderable: true, title: 'Data de Criação' },
@@ -183,6 +188,9 @@ class UserTable extends React.Component {
 }
 
 UserTable.propTypes = {
+  company: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+  }).isRequired,
   handleDeleteUser: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   team: PropTypes.arrayOf(PropTypes.shape({

--- a/packages/pilot/src/containers/Settings/Company/TeamInfoTab/TeamManagement/index.js
+++ b/packages/pilot/src/containers/Settings/Company/TeamInfoTab/TeamManagement/index.js
@@ -54,6 +54,7 @@ class MenagementTeam extends React.Component {
 
   renderContent () {
     const {
+      company,
       createUserStatus,
       deleteUserStatus,
       handleCreateUser,
@@ -69,6 +70,7 @@ class MenagementTeam extends React.Component {
     return (
       <Fragment>
         <AddNewUserModal
+          company={company}
           isOpen={isModalOpened}
           handleCloseModal={this.handleCloseModal}
           handleCreateUser={handleCreateUser}
@@ -116,6 +118,7 @@ class MenagementTeam extends React.Component {
         )}
         <CardContent>
           <UserTable
+            company={company}
             handleDeleteUser={handleDeleteUser}
             t={t}
             team={team}
@@ -153,6 +156,9 @@ class MenagementTeam extends React.Component {
 }
 
 MenagementTeam.propTypes = {
+  company: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+  }).isRequired,
   createUserStatus: PropTypes.shape({
     error: PropTypes.string,
     loading: PropTypes.bool,

--- a/packages/pilot/src/containers/Settings/Company/TeamInfoTab/index.js
+++ b/packages/pilot/src/containers/Settings/Company/TeamInfoTab/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import TeamManagement from './TeamManagement'
 
 const TeamInfoTab = ({
+  company,
   createUserStatus,
   deleteUserStatus,
   handleCreateUser,
@@ -12,6 +13,7 @@ const TeamInfoTab = ({
   team,
 }) => (
   <TeamManagement
+    company={company}
     createUserStatus={createUserStatus}
     deleteUserStatus={deleteUserStatus}
     handleCreateUser={handleCreateUser}
@@ -23,6 +25,9 @@ const TeamInfoTab = ({
 )
 
 TeamInfoTab.propTypes = {
+  company: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+  }).isRequired,
   createUserStatus: PropTypes.shape({
     error: PropTypes.string,
     loading: PropTypes.bool,

--- a/packages/pilot/src/containers/Settings/Company/index.js
+++ b/packages/pilot/src/containers/Settings/Company/index.js
@@ -122,6 +122,7 @@ class CompanySettings extends Component {
         {selectedIndex === 2
           && (
             <TeamInfoTab
+              company={company}
               createUserStatus={createUserStatus}
               deleteUserStatus={deleteUserStatus}
               handleCreateUser={handleCreateUser}

--- a/packages/pilot/src/containers/Settings/Company/index.js
+++ b/packages/pilot/src/containers/Settings/Company/index.js
@@ -83,10 +83,7 @@ class CompanySettings extends Component {
           >
             <TabItem text={t('pages.settings.company.tab.general')} />
             <TabItem text={t('pages.settings.company.tab.products')} />
-            {!isPaymentLink(company)
-              ? <TabItem text={t('pages.settings.company.tab.team')} />
-              : <></>
-            }
+            <TabItem text={t('pages.settings.company.tab.team')} />
             <TabItem text={t('pages.settings.company.tab.register')} />
           </TabBar>
         </CardContent>

--- a/packages/pilot/src/containers/Sidebar/Sections.js
+++ b/packages/pilot/src/containers/Sidebar/Sections.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  propOr,
+  __,
+} from 'ramda'
+
+import SidebarSections from '../../components/SidebarSections'
+import isPaymentLink from '../../validation/isPaymentLink'
+
+import formatDecimalCurrency from '../../formatters/decimalCurrency'
+
+const MINIMUM_API_VALUE = 100
+
+const Sections = ({
+  balance,
+  companyType,
+  onWithdraw,
+  t,
+  transfersPricing,
+}) => {
+  const getFrombalance = propOr(null, __, balance)
+  const available = getFrombalance('available')
+
+  const minimumWithdrawalValue = transfersPricing.ted + MINIMUM_API_VALUE
+  const isCompanyNotPaymentLink = !!companyType && !isPaymentLink(companyType)
+
+  return (
+    <SidebarSections
+      sections={[
+        {
+          action: onWithdraw,
+          actionTitle: t('pages.sidebar.withdraw'),
+          disabled: available <= minimumWithdrawalValue,
+          showButton: isCompanyNotPaymentLink,
+          title: t('pages.sidebar.available'),
+          value: <span><small>{t('pages.sidebar.currency_symbol')}</small> {formatDecimalCurrency(available)}</span>,
+        },
+      ]}
+    />
+  )
+}
+
+Sections.propTypes = {
+  balance: PropTypes.shape({
+    available: PropTypes.number,
+  }).isRequired,
+  companyType: PropTypes.string,
+  onWithdraw: PropTypes.func,
+  t: PropTypes.func.isRequired,
+  transfersPricing: PropTypes.shape({
+    ted: PropTypes.number,
+  }),
+}
+
+Sections.defaultProps = {
+  companyType: '',
+  onWithdraw: null,
+  transfersPricing: {},
+}
+
+export default Sections

--- a/packages/pilot/src/containers/Sidebar/index.js
+++ b/packages/pilot/src/containers/Sidebar/index.js
@@ -4,6 +4,8 @@ import {
   always,
   equals,
   ifElse,
+  prop,
+  sortBy,
 } from 'ramda'
 
 import {
@@ -127,7 +129,7 @@ const SidebarContainer = ({
       }
 
       <SidebarLinks>
-        {links.map(({
+        {sortBy(prop('relevance'), links).map(({
           active,
           exact,
           icon: Icon,

--- a/packages/pilot/src/containers/Sidebar/index.js
+++ b/packages/pilot/src/containers/Sidebar/index.js
@@ -40,6 +40,7 @@ const SidebarContainer = ({
   logo: Logo,
   onLinkClick,
   onWithdraw,
+  showBalance,
   t,
   transfersPricing,
 }) => {
@@ -90,15 +91,19 @@ const SidebarContainer = ({
           <SidebarSummary
             collapsed={summaryCollapsed}
             onClick={handleToggleSummary}
-            subtitle={summarySubtitle}
+            subtitle={
+              showBalance
+                ? summarySubtitle
+                : ''
+            }
             title={companyName}
           >
-            {renderSections()}
+            {showBalance && renderSections()}
           </SidebarSummary>
         )
       }
 
-      {collapsed
+      {showBalance && collapsed
         && (
           <Popover
             base="dark"
@@ -164,6 +169,7 @@ SidebarContainer.propTypes = {
   logo: PropTypes.func.isRequired,
   onLinkClick: PropTypes.func.isRequired,
   onWithdraw: PropTypes.func,
+  showBalance: PropTypes.bool,
   t: PropTypes.func.isRequired,
   transfersPricing: PropTypes.shape({
     ted: PropTypes.number,
@@ -179,6 +185,7 @@ SidebarContainer.defaultProps = {
   companyName: '',
   companyType: '',
   onWithdraw: null,
+  showBalance: false,
   transfersPricing: {},
 }
 

--- a/packages/pilot/src/containers/Sidebar/index.js
+++ b/packages/pilot/src/containers/Sidebar/index.js
@@ -1,11 +1,9 @@
-import React, { isValidElement } from 'react'
+import React, { useState, isValidElement } from 'react'
 import PropTypes from 'prop-types'
 import {
-  propOr,
-  __,
-  ifElse,
-  equals,
   always,
+  equals,
+  ifElse,
 } from 'ramda'
 
 import {
@@ -25,12 +23,8 @@ import IconWallet from 'emblematic-icons/svg/Wallet32.svg'
 
 import style from './style.css'
 
-import SidebarSections from '../../components/SidebarSections'
+import Sections from './Sections'
 import SidebarSummary from '../../components/SidebarSummary'
-import formatDecimalCurrency from '../../formatters/decimalCurrency'
-import isPaymentLink from '../../validation/isPaymentLink'
-
-const MINIMUM_API_VALUE = 100
 
 const getMenuIcon = ifElse(
   equals(true),
@@ -38,155 +32,115 @@ const getMenuIcon = ifElse(
   always(IconMenuNotCollapsed)
 )
 
-class SidebarContainer extends React.Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      collapsed: false,
-      summaryCollapsed: false,
-    }
+const SidebarContainer = ({
+  balance,
+  companyName,
+  companyType,
+  links,
+  logo: Logo,
+  onLinkClick,
+  onWithdraw,
+  t,
+  transfersPricing,
+}) => {
+  const [collapsed, setCollapsed] = useState(false)
+  const [summaryCollapsed, setSummaryCollapsed] = useState(false)
 
-    this.handleToggleSidebar = this.handleToggleSidebar.bind(this)
-  }
+  const handleToggleSidebar = () => setCollapsed(!collapsed)
 
-  handleToggleSidebar () {
-    const { collapsed } = this.state
-    this.setState({ collapsed: !collapsed })
-  }
+  const handleToggleSummary = () => setSummaryCollapsed(!summaryCollapsed)
 
-  renderSections () {
-    const {
-      // This block of code is commented because of issue #1159 (https://github.com/pagarme/pilot/issues/1159)
-      // It was commented on to remove the anticipation limits call on Balance page
-      // This code will be used again in the future when ATLAS project implements the anticipation flow
-      // More details in issue #1159
-      // anticipationLimit,
-      balance,
-      companyType,
-      onWithdraw,
-      t,
-      transfersPricing,
-    } = this.props
+  const renderSections = () => (
+    <Sections
+      balance={balance}
+      companyType={companyType}
+      onWithdraw={onWithdraw}
+      t={t}
+      transfersPricing={transfersPricing}
+    />
+  )
 
-    const getFrombalance = propOr(null, __, balance)
-    const available = getFrombalance('available')
+  const MenuIcon = getMenuIcon(collapsed)
 
-    const minimumWithdrawalValue = transfersPricing.ted + MINIMUM_API_VALUE
-    const isCompanyNotPaymentLink = !!companyType && !isPaymentLink(companyType)
+  const summarySubtitle = summaryCollapsed
+    ? t('pages.sidebar.show_balance')
+    : t('pages.sidebar.hide_balance')
 
-    return (
-      <SidebarSections
-        sections={[
-          {
-            action: onWithdraw,
-            actionTitle: t('pages.sidebar.withdraw'),
-            disabled: available <= minimumWithdrawalValue,
-            showButton: isCompanyNotPaymentLink,
-            title: t('pages.sidebar.available'),
-            value: <span><small>{t('pages.sidebar.currency_symbol')}</small> {formatDecimalCurrency(available)}</span>,
-          },
-        ]}
-      />
-    )
-  }
+  return (
+    <Sidebar collapsed={collapsed}>
+      <SidebarHeader>
+        {!collapsed && <Logo width={140} />}
 
-  render () {
-    const {
-      collapsed,
-      summaryCollapsed,
-    } = this.state
-    const {
-      companyName,
-      links,
-      logo: Logo,
-      onLinkClick,
-      t,
-    } = this.props
-
-    const MenuIcon = getMenuIcon(collapsed)
-
-    return (
-      <Sidebar collapsed={collapsed}>
-        <SidebarHeader>
-          {!collapsed && <Logo width={140} />}
-
-          <Button
-            onClick={this.handleToggleSidebar}
-            icon={(
-              <MenuIcon
-                width={24}
-                height={24}
-                className={style.sidebarIcon}
-              />
-            )}
-            fill="clean"
-            relevance="low"
-          />
-        </SidebarHeader>
-
-        {!collapsed
-          && (
-            <SidebarSummary
-              collapsed={summaryCollapsed}
-              onClick={() => this.setState({
-                summaryCollapsed: !summaryCollapsed,
-              })}
-              subtitle={
-                summaryCollapsed
-                  ? t('pages.sidebar.show_balance')
-                  : t('pages.sidebar.hide_balance')
-              }
-              title={companyName}
-            >
-              {this.renderSections()}
-            </SidebarSummary>
-          )
-        }
-
-        {collapsed
-          && (
-            <Popover
-              base="dark"
-              content={(
-                <PopoverContent>
-                  {this.renderSections()}
-                </PopoverContent>
-              )}
-              placement="rightStart"
-            >
-              <SidebarLinks>
-                <SidebarLink
-                  collapsed={collapsed}
-                  onClick={() => null}
-                  icon={<IconWallet width={16} height={16} />}
-                  title={t('pages.sidebar.balance')}
-                />
-              </SidebarLinks>
-            </Popover>
-          )
-        }
-
-        <SidebarLinks>
-          {links.map(({
-            active,
-            exact,
-            icon: Icon,
-            path,
-            title,
-          }) => (
-            <SidebarLink
-              key={path}
-              title={t(title)}
-              active={active}
-              icon={<Icon width={16} height={16} />}
-              collapsed={collapsed}
-              onClick={() => onLinkClick({ active, exact, path })}
+        <Button
+          onClick={handleToggleSidebar}
+          icon={(
+            <MenuIcon
+              width={24}
+              height={24}
+              className={style.sidebarIcon}
             />
-          ))}
-        </SidebarLinks>
-      </Sidebar>
-    )
-  }
+          )}
+          fill="clean"
+          relevance="low"
+        />
+      </SidebarHeader>
+
+      {!collapsed
+        && (
+          <SidebarSummary
+            collapsed={summaryCollapsed}
+            onClick={handleToggleSummary}
+            subtitle={summarySubtitle}
+            title={companyName}
+          >
+            {renderSections()}
+          </SidebarSummary>
+        )
+      }
+
+      {collapsed
+        && (
+          <Popover
+            base="dark"
+            content={(
+              <PopoverContent>
+                {renderSections()}
+              </PopoverContent>
+            )}
+            placement="rightStart"
+          >
+            <SidebarLinks>
+              <SidebarLink
+                collapsed={collapsed}
+                onClick={() => null}
+                icon={<IconWallet width={16} height={16} />}
+                title={t('pages.sidebar.balance')}
+              />
+            </SidebarLinks>
+          </Popover>
+        )
+      }
+
+      <SidebarLinks>
+        {links.map(({
+          active,
+          exact,
+          icon: Icon,
+          path,
+          title,
+        }) => (
+          <SidebarLink
+            key={path}
+            title={t(title)}
+            active={active}
+            icon={<Icon width={16} height={16} />}
+            collapsed={collapsed}
+            onClick={() => onLinkClick({ active, exact, path })}
+          />
+        ))}
+      </SidebarLinks>
+    </Sidebar>
+  )
 }
 
 SidebarContainer.propTypes = {
@@ -197,7 +151,6 @@ SidebarContainer.propTypes = {
   // anticipationLimit: PropTypes.number,
   balance: PropTypes.shape({
     available: PropTypes.number,
-    waitingFunds: PropTypes.number,
   }).isRequired,
   companyName: PropTypes.string,
   companyType: PropTypes.string,

--- a/packages/pilot/src/containers/TransactionDetails/index.js
+++ b/packages/pilot/src/containers/TransactionDetails/index.js
@@ -7,7 +7,6 @@ import {
   applySpec,
   anyPass,
   both,
-  complement,
   contains,
   either,
   equals,
@@ -271,7 +270,6 @@ class TransactionDetails extends Component {
     const {
       actionLabels,
       headerLabels,
-      isPaymentLink,
       loading: {
         reprocess,
       },
@@ -338,22 +336,29 @@ class TransactionDetails extends Component {
       return []
     }
 
-    const isNotPaymentLink = complement(() => isPaymentLink)
-
     const detailsHeadActions = pipe(
       juxt([
         ifElse(
-          propEq('capturable', true),
+          both(
+            propEq('capturable', true),
+            always(permissions.capture)
+          ),
           always(onCaptureAction),
           always(null)
         ),
         ifElse(
-          both(propEq('reprocessable', true), isNotPaymentLink),
+          both(
+            propEq('reprocessable', true),
+            always(permissions.reprocess)
+          ),
           always(onReprocessAction),
           always(null)
         ),
         ifElse(
-          propEq('refundable', true),
+          both(
+            propEq('refundable', true),
+            always(permissions.refund)
+          ),
           always(onRefundAction),
           always(null)
         ),
@@ -830,7 +835,6 @@ TransactionDetails.propTypes = {
     payment_date: PropTypes.instanceOf(moment),
     status: PropTypes.string,
   })).isRequired,
-  isPaymentLink: PropTypes.bool.isRequired,
   loading: PropTypes.shape({
     reprocess: PropTypes.bool,
   }),
@@ -858,6 +862,7 @@ TransactionDetails.propTypes = {
     title: PropTypes.string,
   }).isRequired,
   permissions: PropTypes.shape({
+    capture: PropTypes.bool.isRequired,
     manualReview: PropTypes.bool.isRequired,
     refund: PropTypes.bool.isRequired,
     reprocess: PropTypes.bool.isRequired,

--- a/packages/pilot/src/pages/LoggedArea/Header.js
+++ b/packages/pilot/src/pages/LoggedArea/Header.js
@@ -59,7 +59,7 @@ const Header = ({
 
   return (
     <HeaderContainer
-      companyType={company.type}
+      company={company}
       onBack={goBack}
       onLogout={onLogout}
       onSettings={() => push(routes.accountSettings.path)}

--- a/packages/pilot/src/pages/LoggedArea/Header.js
+++ b/packages/pilot/src/pages/LoggedArea/Header.js
@@ -11,7 +11,6 @@ import {
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 
-import routes from './routes'
 import { requestLogout } from '../Account/actions/actions'
 import isCompanyPaymentLink from '../../validation/isPaymentLink'
 import isNilOrEmpty from '../../validation/isNilOrEmpty'
@@ -48,6 +47,7 @@ const Header = ({
     pathname,
   },
   onLogout,
+  routes,
   sessionId,
   t,
   user,
@@ -90,6 +90,14 @@ Header.propTypes = {
     pathname: PropTypes.string.isRequired,
   }).isRequired,
   onLogout: PropTypes.func.isRequired,
+  routes: PropTypes.shape({
+    accountSettings: PropTypes.shape({
+      path: PropTypes.string,
+    }),
+    emptyState: PropTypes.shape({
+      path: PropTypes.string,
+    }),
+  }).isRequired,
   sessionId: PropTypes.string,
   t: PropTypes.func.isRequired,
   user: PropTypes.shape({

--- a/packages/pilot/src/pages/LoggedArea/Sidebar.js
+++ b/packages/pilot/src/pages/LoggedArea/Sidebar.js
@@ -6,7 +6,6 @@ import {
   isNil,
   pipe,
   split,
-  values,
 } from 'ramda'
 
 import {
@@ -15,10 +14,9 @@ import {
 } from 'react-router-dom'
 
 import SidebarContainer from '../../containers/Sidebar'
-
-import routes from './routes'
-
 import Logo from '../../components/Logo'
+
+import isLinkmeSeller from '../../validation/isLinkmeSeller'
 
 const removeRouteParams = pipe(
   split(':'),
@@ -40,28 +38,29 @@ const Sidebar = ({
   // More details in issue #1159
   // anticipationLimit,
   balance,
-  companyCanCreateRecipient,
   companyName,
   companyType,
   history,
   location: { pathname },
   recipientId,
+  routes,
   sessionId,
   t,
   transfersPricing,
+  user,
 }) => (
   <SidebarContainer
     balance={balance}
     companyName={companyName}
     companyType={companyType}
-    links={values(routes)
-      .filter(({ hidden, validateVisibility }) => {
-        if (validateVisibility) {
-          return validateVisibility(companyCanCreateRecipient, companyType)
-        }
-
-        return !hidden
-      })
+    showBalance={!isLinkmeSeller({
+      company: {
+        type: companyType,
+      },
+      user,
+    })}
+    links={routes
+      .filter(({ hidden }) => !hidden)
       .map(route => ({
         ...route,
         active: pathname.includes(removeRouteParams(route.path)),
@@ -90,7 +89,6 @@ Sidebar.propTypes = {
   balance: PropTypes.shape({
     available: PropTypes.number,
   }).isRequired,
-  companyCanCreateRecipient: PropTypes.bool,
   companyName: PropTypes.string,
   companyType: PropTypes.string,
   history: PropTypes.shape({
@@ -100,10 +98,19 @@ Sidebar.propTypes = {
     pathname: PropTypes.string,
   }).isRequired,
   recipientId: PropTypes.string,
+  routes: PropTypes.arrayOf(
+    PropTypes.shape({
+      hidden: PropTypes.bool,
+      path: PropTypes.string,
+    })
+  ).isRequired,
   sessionId: PropTypes.string,
   t: PropTypes.func.isRequired,
   transfersPricing: PropTypes.shape({
     ted: PropTypes.number,
+  }),
+  user: PropTypes.shape({
+    permission: PropTypes.string,
   }),
 }
 
@@ -113,12 +120,12 @@ Sidebar.defaultProps = {
   // This code will be used again in the future when ATLAS project implements the anticipation flow
   // More details in issue #1159
   // anticipationLimit: null,
-  companyCanCreateRecipient: false,
   companyName: '',
   companyType: '',
   recipientId: null,
   sessionId: '',
   transfersPricing: {},
+  user: {},
 }
 
 export default withRouter(Sidebar)

--- a/packages/pilot/src/pages/LoggedArea/Sidebar.test.js
+++ b/packages/pilot/src/pages/LoggedArea/Sidebar.test.js
@@ -1,16 +1,25 @@
 import React from 'react'
+import { values } from 'ramda'
 import { MemoryRouter } from 'react-router-dom'
 import { render } from '@testing-library/react'
 import Sidebar from './Sidebar'
 
+import buildRoutes from './routes'
+
 test('should not show recipient tab when companyCanCreateRecipient is false', () => {
+  const company = {
+    marketplace: { test: { can_create_recipient: false } },
+  }
+
+  const routes = buildRoutes({ company, environment: 'test' })
+
   const { container, queryByText } = render(
     <Sidebar
       balance={{
         available: 10,
       }}
-      companyCanCreateRecipient={false}
       t={v => v}
+      routes={values(routes)}
     />,
     { wrapper: MemoryRouter }
   )
@@ -20,12 +29,18 @@ test('should not show recipient tab when companyCanCreateRecipient is false', ()
 })
 
 test('should show recipient tab when companyCanCreateRecipient is true', () => {
+  const company = {
+    marketplace: { test: { can_create_recipient: true } },
+  }
+
+  const routes = buildRoutes({ company, environment: 'test' })
+
   const { container, getByText } = render(
     <Sidebar
       balance={{
         available: 10,
       }}
-      companyCanCreateRecipient
+      routes={values(routes)}
       t={v => v}
     />,
     { wrapper: MemoryRouter }
@@ -35,14 +50,20 @@ test('should show recipient tab when companyCanCreateRecipient is true', () => {
   expect(container).toMatchSnapshot()
 })
 
-test('should show recipient tab when companyType is paymentLink', () => {
+test('should not show recipient tab when companyType is paymentLink', () => {
+  const company = {
+    marketplace: { test: { can_create_recipient: true } },
+    type: 'payment_link_app',
+  }
+
+  const routes = buildRoutes({ company, environment: 'test' })
+
   const { container, queryByText } = render(
     <Sidebar
       balance={{
         available: 10,
       }}
-      companyCanCreateRecipient
-      companyType="payment_link_app"
+      routes={values(routes)}
       t={v => v}
     />,
     { wrapper: MemoryRouter }

--- a/packages/pilot/src/pages/LoggedArea/__snapshots__/Sidebar.test.js.snap
+++ b/packages/pilot/src/pages/LoggedArea/__snapshots__/Sidebar.test.js.snap
@@ -28,12 +28,14 @@ exports[`should not show recipient tab when companyCanCreateRecipient is false 1
     <div
       class="summary expanded"
     >
-      <button
+      <span
         class="title"
+      />
+      <button
+        class="button"
         role="link"
         type="button"
       >
-        
         <span
           class="subtitle"
         >
@@ -178,6 +180,129 @@ exports[`should not show recipient tab when companyCanCreateRecipient is false 1
 </div>
 `;
 
+exports[`should not show recipient tab when companyType is paymentLink 1`] = `
+<div>
+  <aside
+    class="undefined"
+  >
+    <header>
+      <svg
+        data-file-name="SvgLogoLive"
+        width="140"
+      />
+      <button
+        class=""
+        type="button"
+      >
+        <svg
+          class="sidebarIcon"
+          data-file-name="SvgMenuNotCollapsed24"
+          height="24"
+          width="24"
+        />
+        <span
+          style="height: 0px; left: 0px; top: 0px; width: 0px;"
+        />
+      </button>
+    </header>
+    <div
+      class="summary expanded"
+    >
+      <span
+        class="title"
+      />
+      <button
+        class="button"
+        role="link"
+        type="button"
+      >
+        <span
+          class="subtitle"
+        >
+          pages.sidebar.hide_balance
+          <div
+            class="undefined"
+          />
+          <svg
+            data-file-name="SvgChevronUp32"
+            height="16"
+            width="16"
+          />
+        </span>
+      </button>
+      <div
+        class="sections"
+      >
+        <ul>
+          <li
+            class="item"
+          >
+            <span
+              class="title"
+            >
+              pages.sidebar.available
+            </span>
+            <div
+              class="value"
+            >
+              <span>
+                <small>
+                  pages.sidebar.currency_symbol
+                </small>
+                 
+                0,10
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <nav>
+      <ul>
+        <li
+          class=""
+        >
+          <button
+            role="link"
+            type="button"
+          >
+            <div>
+              <span>
+                <svg
+                  data-file-name="SvgCheckout32"
+                  height="16"
+                  width="16"
+                />
+              </span>
+              pages.transactions.title
+            </div>
+          </button>
+        </li>
+        <li
+          class=""
+        >
+          <button
+            role="link"
+            type="button"
+          >
+            <div>
+              <span>
+                <svg
+                  data-file-name="SvgLink32"
+                  height="16"
+                  width="16"
+                />
+              </span>
+              pages.payment_links.title
+            </div>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+</div>
+`;
+
 exports[`should show recipient tab when companyCanCreateRecipient is true 1`] = `
 <div>
   <aside
@@ -206,12 +331,14 @@ exports[`should show recipient tab when companyCanCreateRecipient is true 1`] = 
     <div
       class="summary expanded"
     >
-      <button
+      <span
         class="title"
+      />
+      <button
+        class="button"
         role="link"
         type="button"
       >
-        
         <span
           class="subtitle"
         >
@@ -347,184 +474,6 @@ exports[`should show recipient tab when companyCanCreateRecipient is true 1`] = 
                 />
               </span>
               pages.recipients.title
-            </div>
-          </button>
-        </li>
-        <li
-          class=""
-        >
-          <button
-            role="link"
-            type="button"
-          >
-            <div>
-              <span>
-                <svg
-                  data-file-name="SvgWrench32"
-                  height="16"
-                  width="16"
-                />
-              </span>
-              pages.settings.company.menu
-            </div>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </aside>
-</div>
-`;
-
-exports[`should show recipient tab when companyType is paymentLink 1`] = `
-<div>
-  <aside
-    class="undefined"
-  >
-    <header>
-      <svg
-        data-file-name="SvgLogoLive"
-        width="140"
-      />
-      <button
-        class=""
-        type="button"
-      >
-        <svg
-          class="sidebarIcon"
-          data-file-name="SvgMenuNotCollapsed24"
-          height="24"
-          width="24"
-        />
-        <span
-          style="height: 0px; left: 0px; top: 0px; width: 0px;"
-        />
-      </button>
-    </header>
-    <div
-      class="summary expanded"
-    >
-      <button
-        class="title"
-        role="link"
-        type="button"
-      >
-        
-        <span
-          class="subtitle"
-        >
-          pages.sidebar.hide_balance
-          <div
-            class="undefined"
-          />
-          <svg
-            data-file-name="SvgChevronUp32"
-            height="16"
-            width="16"
-          />
-        </span>
-      </button>
-      <div
-        class="sections"
-      >
-        <ul>
-          <li
-            class="item"
-          >
-            <span
-              class="title"
-            >
-              pages.sidebar.available
-            </span>
-            <div
-              class="value"
-            >
-              <span>
-                <small>
-                  pages.sidebar.currency_symbol
-                </small>
-                 
-                0,10
-              </span>
-            </div>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <nav>
-      <ul>
-        <li
-          class=""
-        >
-          <button
-            role="link"
-            type="button"
-          >
-            <div>
-              <span>
-                <svg
-                  data-file-name="SvgHome32"
-                  height="16"
-                  width="16"
-                />
-              </span>
-              pages.home.title
-            </div>
-          </button>
-        </li>
-        <li
-          class=""
-        >
-          <button
-            role="link"
-            type="button"
-          >
-            <div>
-              <span>
-                <svg
-                  data-file-name="SvgHeartRate32"
-                  height="16"
-                  width="16"
-                />
-              </span>
-              pages.balance.title
-            </div>
-          </button>
-        </li>
-        <li
-          class=""
-        >
-          <button
-            role="link"
-            type="button"
-          >
-            <div>
-              <span>
-                <svg
-                  data-file-name="SvgCheckout32"
-                  height="16"
-                  width="16"
-                />
-              </span>
-              pages.transactions.title
-            </div>
-          </button>
-        </li>
-        <li
-          class=""
-        >
-          <button
-            role="link"
-            type="button"
-          >
-            <div>
-              <span>
-                <svg
-                  data-file-name="SvgLink32"
-                  height="16"
-                  width="16"
-                />
-              </span>
-              pages.payment_links.title
             </div>
           </button>
         </li>

--- a/packages/pilot/src/pages/LoggedArea/index.js
+++ b/packages/pilot/src/pages/LoggedArea/index.js
@@ -11,7 +11,11 @@ import { translate } from 'react-i18next'
 import {
   applySpec,
   compose,
+  find,
   path,
+  pipe,
+  prop,
+  propEq,
   values,
 } from 'ramda'
 import { Layout } from 'former-kit'
@@ -55,6 +59,12 @@ const enhanced = compose(
   connect(mapStateToProps)
 )
 
+const getDefaultRoutePath = pipe(
+  values,
+  find(propEq('defaultRoute', true)),
+  prop('path')
+)
+
 const LoggedArea = ({
   // This block of code is commented because of issue #1159 (https://github.com/pagarme/pilot/issues/1159)
   // It was commented on to remove the anticipation limits call on Balance page
@@ -74,6 +84,8 @@ const LoggedArea = ({
     environment,
     user,
   })
+
+  const defaultRoute = getDefaultRoutePath(routes)
 
   return (
     <Layout
@@ -119,7 +131,7 @@ const LoggedArea = ({
                 component={component}
               />
             ))}
-            <Redirect to="/home" />
+            <Redirect to={defaultRoute} />
           </Switch>
         </Suspense>
       </ErrorBoundary>

--- a/packages/pilot/src/pages/LoggedArea/routes.js
+++ b/packages/pilot/src/pages/LoggedArea/routes.js
@@ -1,3 +1,17 @@
+import {
+  always,
+  assocPath,
+  both,
+  complement,
+  cond,
+  ifElse,
+  mergeRight,
+  pathEq,
+  pick,
+  pipe,
+  T,
+} from 'ramda'
+
 import HeartRate32 from 'emblematic-icons/svg/HeartRate32.svg'
 import Wrench32 from 'emblematic-icons/svg/Wrench32.svg'
 import Home32 from 'emblematic-icons/svg/Home32.svg'
@@ -19,28 +33,13 @@ import {
   PaymentLinks,
 } from './dynamicImports'
 
+import isLinkmeSeller from '../../validation/isLinkmeSeller'
+
 /* eslint-disable sort-keys */
-export default {
-  accountSettings: {
-    component: UserSettings,
-    exact: true,
-    hidden: true,
-    icon: Wrench32,
-    path: '/account',
-    title: 'pages.settings.user.menu',
-  },
-  anticipation: {
-    component: Anticipation,
-    exact: true,
-    hidden: true,
-    icon: HeartRate32,
-    path: '/anticipation/:id?',
-    title: 'pages.anticipation.title',
-  },
+const sidebarRoutes = {
   home: {
     component: Home,
     exact: true,
-    dafaultRoute: true,
     icon: Home32,
     path: '/home',
     title: 'pages.home.title',
@@ -67,6 +66,33 @@ export default {
     title: 'pages.payment_links.title',
     icon: Link32,
   },
+  companySettings: {
+    component: CompanySettings,
+    exact: true,
+    icon: Wrench32,
+    path: '/settings',
+    title: 'pages.settings.company.menu',
+  },
+}
+
+export const defaultRoutes = {
+  ...sidebarRoutes,
+  accountSettings: {
+    component: UserSettings,
+    exact: true,
+    hidden: true,
+    icon: Wrench32,
+    path: '/account',
+    title: 'pages.settings.user.menu',
+  },
+  anticipation: {
+    component: Anticipation,
+    exact: true,
+    hidden: true,
+    icon: HeartRate32,
+    path: '/anticipation/:id?',
+    title: 'pages.anticipation.title',
+  },
   paymentLinksDetails: {
     exact: true,
     hidden: true,
@@ -86,14 +112,22 @@ export default {
     path: '/withdraw/:id?',
     title: 'pages.withdraw.title',
   },
+  emptyState: {
+    component: EmptyState,
+    hidden: true,
+    path: '/welcome',
+    title: 'pages.empty_state.title',
+  },
+}
+
+const recipientsRoutes = {
   recipients: {
-    validateVisibility: (companyCanCreateRecipient, companyType) => companyCanCreateRecipient && companyType !== 'payment_link_app',
-    hidden: false,
-    title: 'pages.recipients.title',
-    path: '/recipients',
     component: Recipients,
-    icon: Anticipation32,
     exact: true,
+    hidden: false,
+    icon: Anticipation32,
+    path: '/recipients',
+    title: 'pages.recipients.title',
   },
   recipientsAdd: {
     hidden: true,
@@ -105,19 +139,43 @@ export default {
     path: '/recipients/detail',
     title: 'pages.recipient_detail.title',
   },
-  emptyState: {
-    component: EmptyState,
-    hidden: true,
-    path: '/welcome',
-    title: 'pages.empty_state.title',
-  },
-  companySettings: {
-    component: CompanySettings,
-    exact: true,
-    icon: Wrench32,
-    path: '/settings',
-    title: 'pages.settings.company.menu',
-  },
 }
 
 /* eslint-enable sort-keys */
+
+const setDefaultRoute = routeName => assocPath([
+  routeName, 'defaultRoute',
+], true)
+
+const addRoutesOnCondition = (condition, routesToAdd) => ifElse(
+  condition,
+  always(routesToAdd),
+  always({})
+)
+
+const canCreateRecipients = both(
+  ({ environment, ...obj }) => pathEq(
+    ['company', 'marketplace', environment, 'can_create_recipient'],
+    true,
+    obj
+  ),
+  complement(pathEq(['company', 'type'], 'payment_link_app'))
+)
+
+const buildDefaultRoutes = routes => pipe(
+  addRoutesOnCondition(canCreateRecipients, recipientsRoutes),
+  mergeRight(routes),
+  setDefaultRoute('home')
+)
+
+const buildLinkmeSellerRoutes = routes => pipe(
+  always(pick(['transactions', 'paymentLinks', 'accountSettings'], routes)),
+  setDefaultRoute('paymentLinks')
+)
+
+const buildRoutes = cond([
+  [isLinkmeSeller, buildLinkmeSellerRoutes(defaultRoutes)],
+  [T, buildDefaultRoutes(defaultRoutes)],
+])
+
+export default buildRoutes

--- a/packages/pilot/src/pages/LoggedArea/routes.js
+++ b/packages/pilot/src/pages/LoggedArea/routes.js
@@ -42,6 +42,7 @@ const sidebarRoutes = {
     exact: true,
     icon: Home32,
     path: '/home',
+    relevance: 0,
     title: 'pages.home.title',
   },
   balance: {
@@ -49,6 +50,7 @@ const sidebarRoutes = {
     exact: true,
     icon: HeartRate32,
     path: '/balance/:id?',
+    relevance: 1,
     title: 'pages.balance.title',
   },
   transactions: {
@@ -56,6 +58,7 @@ const sidebarRoutes = {
     exact: true,
     icon: Checkout32,
     path: '/transactions',
+    relevance: 2,
     title: 'pages.transactions.title',
   },
   paymentLinks: {
@@ -63,6 +66,7 @@ const sidebarRoutes = {
     exact: true,
     hidden: false,
     path: '/payment-links',
+    relevance: 3,
     title: 'pages.payment_links.title',
     icon: Link32,
   },
@@ -71,6 +75,7 @@ const sidebarRoutes = {
     exact: true,
     icon: Wrench32,
     path: '/settings',
+    relevance: 5,
     title: 'pages.settings.company.menu',
   },
 }
@@ -127,6 +132,7 @@ const recipientsRoutes = {
     hidden: false,
     icon: Anticipation32,
     path: '/recipients',
+    relevance: 4,
     title: 'pages.recipients.title',
   },
   recipientsAdd: {

--- a/packages/pilot/src/pages/LoggedArea/routes.test.js
+++ b/packages/pilot/src/pages/LoggedArea/routes.test.js
@@ -1,0 +1,98 @@
+import {
+  keys,
+  mergeRight,
+  pick,
+} from 'ramda'
+
+import buildRoutes, {
+  defaultRoutes,
+} from './routes'
+
+describe('When is link.me company', () => {
+  const company = { type: 'payment_link_app' }
+
+  it('should not allow access to recipients routes', () => {
+    const routes = buildRoutes({
+      company: mergeRight(company, {
+        marketplace: { test: { can_create_recipient: true } },
+      }),
+      environment: 'test',
+      user: { permission: 'admin' },
+    })
+
+    const result = pick([
+      'recipients',
+      'recipientsAdd',
+      'recipientsDetail',
+    ], routes)
+
+    expect(result).toEqual({})
+  })
+
+  describe('And admin user', () => {
+    it('should allow access to all default routes', () => {
+      const payload = {
+        company,
+        user: { permission: 'admin' },
+      }
+
+      const routes = keys(buildRoutes(payload))
+
+      expect(routes).toEqual(keys(defaultRoutes))
+    })
+  })
+
+  describe('And not admin user', () => {
+    it('should only allow access to transactions, paymentLinks and accountSettings', () => {
+      const payload = {
+        company,
+        user: { permission: 'read_write' },
+      }
+
+      const routes = keys(buildRoutes(payload))
+
+      const expected = [
+        'transactions',
+        'paymentLinks',
+        'accountSettings',
+      ]
+
+      expect(routes).toEqual(expected)
+    })
+  })
+})
+
+describe('When is of any company type', () => {
+  const company = { type: 'default' }
+
+  describe('And has marketplace permissions', () => {
+    it('should allow access to recipients routes', () => {
+      const payload = {
+        company: mergeRight(company, {
+          marketplace: { test: { can_create_recipient: true } },
+        }),
+        environment: 'test',
+        user: { permission: 'admin' },
+      }
+
+      const routes = keys(buildRoutes(payload))
+
+      const expected = ['recipients', 'recipientsAdd', 'recipientsDetail']
+
+      expect(routes).toEqual(expect.arrayContaining(expected))
+    })
+  })
+
+  it('should allow access to all default routes', () => {
+    const payload = {
+      company,
+      user: { permission: 'admin' },
+    }
+
+    const routes = buildRoutes(payload)
+
+    const expected = keys(defaultRoutes)
+
+    expect(keys(routes)).toEqual(expect.arrayContaining(expected))
+  })
+})

--- a/packages/pilot/src/pages/Transactions/Details/Details.js
+++ b/packages/pilot/src/pages/Transactions/Details/Details.js
@@ -39,6 +39,7 @@ import Reprocess from '../../Reprocess'
 import currencyFormatter from '../../../formatters/decimalCurrency'
 import getColumnFormatter from '../../../formatters/columnTranslator'
 import checkIsPaymentLink from '../../../validation/isPaymentLink'
+import isLinkmeSeller from '../../../validation/isLinkmeSeller'
 import installmentTableColumns from '../../../components/RecipientSection/installmentTableColumns'
 import ManualReview from '../../ManualReview'
 import TransactionDetailsContainer from '../../../containers/TransactionDetails'
@@ -673,7 +674,7 @@ class TransactionDetails extends Component {
     }
 
     const nextTransactionId = transaction.nextId
-    const isPaymentLink = checkIsPaymentLink(company)
+    const isLinkmeCompany = checkIsPaymentLink(company)
 
     return (
       <Fragment>
@@ -685,7 +686,6 @@ class TransactionDetails extends Component {
           expandRecipients={expandRecipients}
           headerLabels={headerLabels}
           installmentColumns={installmentColumns}
-          isPaymentLink={isPaymentLink}
           loading={loading}
           metadataTitle={t('pages.transaction.metadata')}
           nextTransactionId={nextTransactionId}
@@ -705,8 +705,11 @@ class TransactionDetails extends Component {
           permissions={{
             capture: permission !== 'read_only',
             manualReview: permission !== 'read_only',
-            refund: permission !== 'read_only',
-            reprocess: permission !== 'read_only',
+            refund: (
+              permission !== 'read_only'
+              && !isLinkmeSeller({ company, user: { permission } })
+            ),
+            reprocess: permission !== 'read_only' && !isLinkmeCompany,
           }}
           recipientsLabels={recipientsLabels}
           riskLevelsLabels={riskLevelsLabels}

--- a/packages/pilot/src/utils/helpers/getPermission.js
+++ b/packages/pilot/src/utils/helpers/getPermission.js
@@ -1,0 +1,14 @@
+import isPaymentLink from '../../validation/isPaymentLink'
+
+function getPermission (userRole, company, t) {
+  const isPaymentLinkSeller = userRole === 'read_write'
+    && isPaymentLink(company)
+
+  if (isPaymentLinkSeller) {
+    return t('models.user.permission.seller')
+  }
+
+  return t(`models.user.permission.${userRole}`)
+}
+
+export default getPermission

--- a/packages/pilot/src/validation/isLinkmeSeller.js
+++ b/packages/pilot/src/validation/isLinkmeSeller.js
@@ -1,0 +1,18 @@
+import {
+  both,
+  complement,
+  pipe,
+  prop,
+  propEq,
+} from 'ramda'
+
+import isPaymentLink from './isPaymentLink'
+
+const isAdmin = propEq('permission', 'admin')
+
+const isLinkmeSeller = both(
+  pipe(prop('company'), isPaymentLink),
+  pipe(prop('user'), complement(isAdmin))
+)
+
+export default isLinkmeSeller

--- a/packages/pilot/src/validation/isLinkmeSeller.js
+++ b/packages/pilot/src/validation/isLinkmeSeller.js
@@ -3,6 +3,7 @@ import {
   complement,
   pipe,
   prop,
+  propOr,
   propEq,
 } from 'ramda'
 
@@ -12,7 +13,7 @@ const isAdmin = propEq('permission', 'admin')
 
 const isLinkmeSeller = both(
   pipe(prop('company'), isPaymentLink),
-  pipe(prop('user'), complement(isAdmin))
+  pipe(propOr({}, 'user'), complement(isAdmin))
 )
 
 export default isLinkmeSeller


### PR DESCRIPTION
## Contexto
Esta Release consiste das limitações de acesso necessárias para usuários seller de link.me (read_only e read_write). Este tipo de usuário não deve ser capaz de visualizar dados sensíveis da conta como o saldo disponível para saque, e também não deve ser capaz de realizar saques. Usuários seller tem acesso somente às telas de gerenciamento de links de pagamento e de transações.

## Checklist
- [x] Adicionada limitações de acesso para usuários seller de link.me (read_only e read_write)
- [x] Ocultado da sidebar o saldo disponível para saque para usuários seller
- [x] Adicionada a aba Equipe na tela de configurações de conta para usuários admin de link.me

## Como testar?
- Testar roteamento de usuários de acordo com sua permissão
    - Usuários seller (read_write/read_only) devem ter acesso somente à
        - Transações
        - Links de pagamento
        - Configurações de usuário
    - Usuários admin não devem ter acesso às telas de Recebedores
- Usuários Seller não devem ser capazes de realizar saque e visualizar o saldo disponível
- Companies Link.me agora possuem acesso à aba de equipes na tela de configurações de conta