### PR TITLE
EXP-271 - Detalhes de transação - Adiciona permissionamento de ações

### DIFF
--- a/packages/pilot/src/containers/TransactionDetails/index.js
+++ b/packages/pilot/src/containers/TransactionDetails/index.js
@@ -7,7 +7,6 @@ import {
   applySpec,
   anyPass,
   both,
-  complement,
   contains,
   either,
   equals,
@@ -271,7 +270,6 @@ class TransactionDetails extends Component {
     const {
       actionLabels,
       headerLabels,
-      isPaymentLink,
       loading: {
         reprocess,
       },
@@ -338,22 +336,29 @@ class TransactionDetails extends Component {
       return []
     }
 
-    const isNotPaymentLink = complement(() => isPaymentLink)
-
     const detailsHeadActions = pipe(
       juxt([
         ifElse(
-          propEq('capturable', true),
+          both(
+            propEq('capturable', true),
+            always(permissions.capture)
+          ),
           always(onCaptureAction),
           always(null)
         ),
         ifElse(
-          both(propEq('reprocessable', true), isNotPaymentLink),
+          both(
+            propEq('reprocessable', true),
+            always(permissions.reprocess)
+          ),
           always(onReprocessAction),
           always(null)
         ),
         ifElse(
-          propEq('refundable', true),
+          both(
+            propEq('refundable', true),
+            always(permissions.refund)
+          ),
           always(onRefundAction),
           always(null)
         ),
@@ -830,7 +835,6 @@ TransactionDetails.propTypes = {
     payment_date: PropTypes.instanceOf(moment),
     status: PropTypes.string,
   })).isRequired,
-  isPaymentLink: PropTypes.bool.isRequired,
   loading: PropTypes.shape({
     reprocess: PropTypes.bool,
   }),
@@ -858,6 +862,7 @@ TransactionDetails.propTypes = {
     title: PropTypes.string,
   }).isRequired,
   permissions: PropTypes.shape({
+    capture: PropTypes.bool.isRequired,
     manualReview: PropTypes.bool.isRequired,
     refund: PropTypes.bool.isRequired,
     reprocess: PropTypes.bool.isRequired,

--- a/packages/pilot/src/pages/Transactions/Details/Details.js
+++ b/packages/pilot/src/pages/Transactions/Details/Details.js
@@ -39,6 +39,7 @@ import Reprocess from '../../Reprocess'
 import currencyFormatter from '../../../formatters/decimalCurrency'
 import getColumnFormatter from '../../../formatters/columnTranslator'
 import checkIsPaymentLink from '../../../validation/isPaymentLink'
+import isLinkmeSeller from '../../../validation/isLinkmeSeller'
 import installmentTableColumns from '../../../components/RecipientSection/installmentTableColumns'
 import ManualReview from '../../ManualReview'
 import TransactionDetailsContainer from '../../../containers/TransactionDetails'
@@ -673,7 +674,7 @@ class TransactionDetails extends Component {
     }
 
     const nextTransactionId = transaction.nextId
-    const isPaymentLink = checkIsPaymentLink(company)
+    const isLinkmeCompany = checkIsPaymentLink(company)
 
     return (
       <Fragment>
@@ -685,7 +686,6 @@ class TransactionDetails extends Component {
           expandRecipients={expandRecipients}
           headerLabels={headerLabels}
           installmentColumns={installmentColumns}
-          isPaymentLink={isPaymentLink}
           loading={loading}
           metadataTitle={t('pages.transaction.metadata')}
           nextTransactionId={nextTransactionId}
@@ -705,8 +705,11 @@ class TransactionDetails extends Component {
           permissions={{
             capture: permission !== 'read_only',
             manualReview: permission !== 'read_only',
-            refund: permission !== 'read_only',
-            reprocess: permission !== 'read_only',
+            refund: (
+              permission !== 'read_only'
+              && !isLinkmeSeller({ company, user: { permission } })
+            ),
+            reprocess: permission !== 'read_only' && !isLinkmeCompany,
           }}
           recipientsLabels={recipientsLabels}
           riskLevelsLabels={riskLevelsLabels}


### PR DESCRIPTION
## Contexto
Este PR adiciona o uso de permissionamento de ações de transação que já haviamos definido mas não estava em uso (??). Adiciono também a condição de que sellers de link.me não podem estornar transações.         

## Checklist
- [x] Adiciona uso do permissionamento de ações de transação (captura, reprocessamento, estorno etc)
- [x] Refatora permissão de reprocessamento, movendo para a page a lógica de verificação por companies Link.me
- [x] Adiciona bloqueio de seller de link.me para ação de estorno

## Como testar?
1. Faça o login com usuário de escrita/leitura/admin e verifique se o permissionamento está de acordo
    - Companies Linkme - Somente o admin pode fazer estorno
    - Demais companies - Qualquer usuário que não seja `read_only` consegue estornar, reprocessar e capturar transações
