### PR TITLE
fix: hide create payment link for read_only users

### DIFF
--- a/packages/pilot/src/pages/PaymentLinks/List/List.js
+++ b/packages/pilot/src/pages/PaymentLinks/List/List.js
@@ -33,6 +33,11 @@ const defaultColumnSize = {
 }
 
 const mapStateToProps = ({
+  account: {
+    user: {
+      permission,
+    },
+  },
   paymentLinks: {
     filter,
     loadingCreateLink,
@@ -50,6 +55,7 @@ const mapStateToProps = ({
   paymentLinkUrl,
   step,
   totalPaymentLinks,
+  userPermission: permission,
 })
 
 const mapDispatchToProps = {
@@ -138,6 +144,7 @@ const List = ({
   step,
   t,
   totalPaymentLinks,
+  userPermission,
 }) => {
   const [linkFormData, setLinkFormData] = useState(makeDefaulLinkData())
   const [isNewLinkOpen, setIsNewLinkOpen] = useState(false)
@@ -251,14 +258,17 @@ const List = ({
         onPreviousStep={previousStepRequest}
         paymentLink={paymentLinkUrl}
         step={steps[step]}
+        userPermission={userPermission}
         t={t}
       />
       <Grid>
-        <Row>
-          <Col {...defaultColumnSize}>
-            <NewLinksCard onAddPaymentLink={onAddPaymentLink} t={t} />
-          </Col>
-        </Row>
+        {userPermission !== 'read_only' && (
+          <Row>
+            <Col {...defaultColumnSize}>
+              <NewLinksCard onAddPaymentLink={onAddPaymentLink} t={t} />
+            </Col>
+          </Row>
+        )}
         <Row>
           <Col {...defaultColumnSize}>
             <PaymentLinksFilter
@@ -315,6 +325,7 @@ List.propTypes = {
   step: PropTypes.string.isRequired,
   t: PropTypes.func.isRequired,
   totalPaymentLinks: PropTypes.number,
+  userPermission: PropTypes.string.isRequired,
 }
 
 List.defaultProps = {


### PR DESCRIPTION
## Contexto

Esconder botão de "Criar Link de Pagamentos" para clientes com permissão read_only

## Screenshots

![image](https://user-images.githubusercontent.com/3194806/92128420-c316ed80-edd8-11ea-9eb1-ec2809b785cd.png)

## Como testar?

Entrar com um usuário com permissão read_only na tela de listagem de links de pagamento e verificar se o card que contém o botão para criação de novos links está escondido.

## Issue relacionada

[CRED-230](https://mundipagg.atlassian.net/browse/CRED-230)