### PR TITLE
settings: update test fees

### DIFF
--- a/packages/pilot/src/pages/Account/actions/reducer.js
+++ b/packages/pilot/src/pages/Account/actions/reducer.js
@@ -27,8 +27,6 @@ import {
   RECIPIENT_BALANCE_RECEIVE,
 } from './actions'
 
-import environment from '../../../environment'
-
 const getBalance = applySpec({
   available: path(['withdrawal', 'maximum']),
   waitingFunds: path(['balance', 'waiting_funds', 'amount']),
@@ -106,7 +104,7 @@ export default function loginReducer (state = initialState, action) {
 }
 
 const getAntifraudCost = pipe(
-  pathOr([], ['gateway', environment, 'antifraud_cost']),
+  pathOr([], ['gateway', 'live', 'antifraud_cost']),
   find(propEq('name', 'pagarme')),
   prop('cost')
 )
@@ -123,7 +121,7 @@ const findCreditCardMDR = mdrs => mdrs.find(({
 }) => CREDIT_CARD_MDRS_TYPES.includes(paymentMethod))
 
 const getInstallmentsFee = pipe(
-  pathOr([], ['psp', environment, 'mdrs']),
+  pathOr([], ['psp', 'live', 'mdrs']),
   findCreditCardMDR,
   pathOr([], ['installments']),
   when(notDefaultInstallments, always([]))
@@ -132,10 +130,10 @@ const getInstallmentsFee = pipe(
 const getFees = pipe(
   prop('pricing'),
   applySpec({
-    anticipation: path(['psp', environment, 'anticipation']),
+    anticipation: path(['psp', 'live', 'anticipation']),
     antifraud: getAntifraudCost,
-    boleto: path(['gateway', environment, 'boletos', 'payment_fixed_fee']),
-    gateway: path(['gateway', environment, 'transaction_cost', 'credit_card']),
+    boleto: path(['gateway', 'live', 'boletos', 'payment_fixed_fee']),
+    gateway: path(['gateway', 'live', 'transaction_cost', 'credit_card']),
     installments: getInstallmentsFee,
     transfer: path(['transfers', 'ted']),
   })

--- a/packages/pilot/src/pages/Account/actions/reducer.test.js
+++ b/packages/pilot/src/pages/Account/actions/reducer.test.js
@@ -3,7 +3,7 @@ import { selectCompanyFees } from './reducer'
 const companyFactory = mdrs => ({
   pricing: {
     gateway: {
-      test: {
+      live: {
         antifraud_cost: [
           {
             cost: 70,
@@ -28,7 +28,7 @@ const companyFactory = mdrs => ({
       },
     },
     psp: {
-      test: {
+      live: {
         anticipation: 3.14,
         mdrs,
       },


### PR DESCRIPTION
## Contexto
Em sandbox não é possível visualizar as taxas atreladas a company, o que confundia alguns clientes. Foi verificado que as taxas sempre vão ser referentes a **live** independente do ambiente. Dessa forma, foi alterado o caminho de leitura da mesma na pilot.

## Checklist
- [x] Mostrar taxas de company em sandbox
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [x] [CRED-253](https://mundipagg.atlassian.net/browse/CRED-253)
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Screenshots
<!-- Adicione algumas imagens para haver um preview da sua tarefa, para ajudar desenvolvedores e designers a entender facilmente no que você está trabalhando. -->

### Layout:
![image](https://user-images.githubusercontent.com/15900829/92256260-e362ad00-eea9-11ea-92f5-a7500cfa7bc4.png)


### Preview:
![image](https://user-images.githubusercontent.com/15900829/92256557-40f6f980-eeaa-11ea-87a7-7b66a28639c2.png)

