### PR TITLE
EXP-269 feat(zopim): add more user and company tags

### DIFF
--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -148,7 +148,10 @@ const accountEpic = action$ => action$
         env
       )
 
-      zopimAddTags([`nível de acesso do usuário: ${permission}`])
+      zopimAddTags([
+        `nível de acesso do usuário: ${permission}`,
+        `email do usuário: ${email}`,
+      ])
     })
   )
 
@@ -203,10 +206,12 @@ const companyEpic = (action$, state$) => action$.pipe(
     }
     const { value: state } = state$
     const {
+      api_version: apiVersion,
       dateCreated,
       id,
       name,
       status,
+      transfers,
       type,
     } = payload
 
@@ -231,6 +236,9 @@ const companyEpic = (action$, state$) => action$.pipe(
       `tipo da company: ${type}`,
       `id da company: ${id}`,
       'Aplicação: dashboard beta',
+      `status da company: ${status}`,
+      `versão de api da company (live): ${apiVersion.live}`,
+      `saldo bloqueado da company: ${transfers.blocked_balance_amount}`,
     ])
 
     if (status === 'active') {


### PR DESCRIPTION
## Contexto
adicionar as seguintes novas tags ao chat da pilot
1- E-mail que está logado
2- Status da company
3- Versão da API (só live)
4- Saldo bloqueado (live)

## Como testar?
- Rodar o projeto;
- Abrir a aba de network;
- Logar com uma conta e verificar a request feito que obtém os dados da company. Verificar se os campos colocados no código batem com o payload de resposta da API.