### PR TITLE
CRED-225 Buscar as taxas no FeePreset

### DIFF
--- a/packages/pilot/package.json
+++ b/packages/pilot/package.json
@@ -18,7 +18,7 @@
     "moment-timezone": "0.5.27",
     "normalize.css": "8.0.1",
     "p4g4rm3": "0.1.7",
-    "pagarme": "4.12.0",
+    "pagarme": "4.13.0",
     "prop-types": "15.6.2",
     "qs": "6.5.1",
     "ramda": "0.26.1",

--- a/packages/pilot/src/components/FeesDetails/__snapshots__/FeeDetails.test.js.snap
+++ b/packages/pilot/src/components/FeesDetails/__snapshots__/FeeDetails.test.js.snap
@@ -24,6 +24,28 @@ exports[`render 1 installments with all fees and isMDRzao enabled 1`] = `
             </strong>
           </p>
         </div>
+        <div>
+          <p>
+            pages.empty_state.fees.processing
+          </p>
+          <p>
+            <strong>
+              R$ 0,50
+               
+            </strong>
+          </p>
+        </div>
+        <div>
+          <p>
+            pages.empty_state.fees.antifraud
+          </p>
+          <p>
+            <strong>
+              R$ 0,70
+               
+            </strong>
+          </p>
+        </div>
       </div>
     </div>
     <div

--- a/packages/pilot/src/components/FeesDetails/index.js
+++ b/packages/pilot/src/components/FeesDetails/index.js
@@ -42,29 +42,35 @@ const buildCreditCardFees = ({ fees, isMDRzao }) => (
         valueSuffixPath: 'pages.empty_state.fees.per_transaction',
       },
     ]
-    : [
-      ...buildInstallmentsValues('DEFAULT', fees.installments),
-      {
-        translationPath: 'pages.empty_state.fees.processing',
-        type: 'currency',
-        value: fees.gateway,
-      },
-      {
-        translationPath: 'pages.empty_state.fees.antifraud',
-        type: 'currency',
-        value: fees.antifraud,
-      },
-    ])
+    : [...buildInstallmentsValues('DEFAULT', fees.installments)])
+
+const buildProcessingFees = (fees) => {
+  const processingFees = [
+    {
+      translationPath: 'pages.empty_state.fees.processing',
+      type: 'currency',
+      value: fees.gateway,
+    },
+    {
+      translationPath: 'pages.empty_state.fees.antifraud',
+      type: 'currency',
+      value: fees.antifraud,
+    },
+  ]
+
+  return processingFees.filter(v => v.value !== 0)
+}
 
 const FeesDetails = ({ fees, isMDRzao, t }) => {
   const creditCardFees = buildCreditCardFees({ fees, isMDRzao })
+  const processingFees = buildProcessingFees(fees)
 
   return (
     <div>
       <FeeTitleAndValues
         t={t}
         title={t('pages.empty_state.fees.credit_card')}
-        values={creditCardFees}
+        values={[...creditCardFees, ...processingFees]}
       />
       <Flexbox className={styles.marginRight}>
         <FeeTitleAndValues

--- a/packages/pilot/src/pages/Account/actions/actions.js
+++ b/packages/pilot/src/pages/Account/actions/actions.js
@@ -21,5 +21,11 @@ export const receiveCompany = createAction(COMPANY_RECEIVE)
 export const LOGIN_FAIL = 'pilot/account/LOGIN_FAIL'
 export const failLogin = createAction(LOGIN_FAIL)
 
+export const RECIPIENT_RECEIVE = 'pilot/account/RECIPIENT_RECEIVE'
+export const receiveRecipient = createAction(RECIPIENT_RECEIVE)
+
 export const RECIPIENT_BALANCE_RECEIVE = 'pilot/account/RECIPIENT_BALANCE_RECEIVE'
 export const receiveRecipientBalance = createAction(RECIPIENT_BALANCE_RECEIVE)
+
+export const FEE_PRESET_RECEIVE = 'pilot/account/FEE_PRESET_RECEIVE'
+export const receiveFeePreset = createAction(FEE_PRESET_RECEIVE)

--- a/packages/pilot/src/pages/Account/actions/epic.js
+++ b/packages/pilot/src/pages/Account/actions/epic.js
@@ -1,9 +1,7 @@
 import pagarme from 'pagarme'
 import {
   allPass,
-  always,
   complement,
-  cond,
   hasPath,
   identity,
   ifElse,
@@ -12,7 +10,6 @@ import {
   pathEq,
   pathOr,
   propEq,
-  T,
 } from 'ramda'
 import {
   map,
@@ -73,11 +70,6 @@ const hasDashboardAccess = ifElse(
 
 const getRecipientId = pathOr(null, ['account', 'company', 'default_recipient_id', env])
 const getFeePresetId = pathOr(null, ['account', 'defaultRecipient', 'fee_preset_id'])
-
-const getAnticipationType = cond([
-  [pathEq(['capabilities', 'allow_transaction_anticipation'], true), always('MDRZAO')],
-  [T, always('DEFAULT')],
-])
 
 const isNotEmpty = complement(isEmpty)
 
@@ -180,14 +172,12 @@ const companyEpic = (action$, state$) => action$.pipe(
     const { value: state } = state$
     const { account: { client } } = state
 
-    const anticipationType = getAnticipationType(action)
-
     return client
       .transactions
       .all({ count: 1 })
       .then((transactions) => {
         const alreadyTransacted = isNotEmpty(transactions)
-        return { ...action, alreadyTransacted, anticipationType }
+        return { ...action, alreadyTransacted }
       })
       .catch(errorPayload => ({
         error: true,

--- a/packages/pilot/src/pages/Account/actions/reducer.js
+++ b/packages/pilot/src/pages/Account/actions/reducer.js
@@ -20,10 +20,12 @@ import {
 import {
   ACCOUNT_RECEIVE,
   COMPANY_RECEIVE,
+  FEE_PRESET_RECEIVE,
   LOGIN_FAIL,
   LOGIN_RECEIVE,
   LOGIN_REQUEST,
   LOGOUT_RECEIVE,
+  RECIPIENT_RECEIVE,
   RECIPIENT_BALANCE_RECEIVE,
 } from './actions'
 
@@ -33,6 +35,7 @@ const getBalance = applySpec({
 })
 
 const initialState = {
+  defaultRecipient: {},
   loading: false,
   sessionId: null,
 }
@@ -94,6 +97,27 @@ export default function loginReducer (state = initialState, action) {
         state,
         {
           balance: getBalance(action.payload),
+        }
+      )
+    }
+
+    case RECIPIENT_RECEIVE: {
+      return merge(
+        state,
+        {
+          defaultRecipient: action.payload,
+        }
+      )
+    }
+
+    case FEE_PRESET_RECEIVE: {
+      return merge(
+        state,
+        {
+          defaultRecipient: {
+            ...state.defaultRecipient,
+            feePreset: action.payload,
+          },
         }
       )
     }

--- a/packages/pilot/src/pages/Account/actions/reducer.js
+++ b/packages/pilot/src/pages/Account/actions/reducer.js
@@ -191,3 +191,11 @@ export const selectHasBlockedWithdraw = pipe(
   pathOr(0, ['transfers', 'blocked_balance_amount']),
   gte(__, BLOCKED_AMOUNT_LIMIT)
 )
+
+export const selectAnticipationType = ({ company, defaultRecipient }) => {
+  if (company.capabilities.allow_transaction_anticipation) {
+    return 'compulsory'
+  }
+
+  return defaultRecipient.automatic_anticipation_type
+}

--- a/packages/pilot/src/pages/Account/actions/reducer.test.js
+++ b/packages/pilot/src/pages/Account/actions/reducer.test.js
@@ -1,4 +1,4 @@
-import { selectCompanyFees } from './reducer'
+import { selectCompanyFees, selectAnticipationType } from './reducer'
 
 const companyFactory = mdrs => ({
   pricing: {
@@ -203,12 +203,44 @@ describe('selectCompanyFees', () => {
 
     it('should return the correct response', () => {
       expect(fees).toEqual({
-        anticipation: 10,
+        anticipation: 3.14,
         antifraud: 70,
         boleto: 380,
         gateway: 50,
         installments: [{ installment: 1, mdr: 2 }],
         transfer: 367,
+      })
+    })
+  })
+
+  describe('selectAnticipationType', () => {
+    describe('when company has compulsory anticipation set at company level', () => {
+      const company = { capabilities: { allow_transaction_anticipation: true } }
+      const defaultRecipient = { automatic_anticipation_type: 'full' }
+
+      const anticipationType = selectAnticipationType({
+        company,
+        defaultRecipient,
+      })
+
+      it('should have anticipation type equal compulsory', () => {
+        expect(anticipationType).toEqual('compulsory')
+      })
+    })
+
+    describe('when company has not compulsory anticipation set at company level', () => {
+      const company = {
+        capabilities: { allow_transaction_anticipation: false },
+      }
+      const defaultRecipient = { automatic_anticipation_type: 'full' }
+
+      const anticipationType = selectAnticipationType({
+        company,
+        defaultRecipient,
+      })
+
+      it('should return the anticipation type set at the recipient', () => {
+        expect(anticipationType).toEqual('full')
       })
     })
   })

--- a/packages/pilot/src/pages/Account/actions/reducer.test.js
+++ b/packages/pilot/src/pages/Account/actions/reducer.test.js
@@ -52,8 +52,9 @@ describe('selectCompanyFees', () => {
       ],
       payment_method: 'credit_card',
     }])
+    const defaultRecipient = {}
 
-    const fees = selectCompanyFees(company)
+    const fees = selectCompanyFees({ company, defaultRecipient })
 
     it('should return the correct response', () => {
       expect(fees).toEqual({
@@ -76,8 +77,9 @@ describe('selectCompanyFees', () => {
       installments: [{ installment: 1, mdr: 3.79 }],
       payment_method: 'credit_card',
     }])
+    const defaultRecipient = {}
 
-    const fees = selectCompanyFees(company)
+    const fees = selectCompanyFees({ company, defaultRecipient })
 
     it('should return the correct response', () => {
       expect(fees).toEqual({
@@ -104,8 +106,9 @@ describe('selectCompanyFees', () => {
         ],
         payment_method: null,
       }])
+    const defaultRecipient = {}
 
-    const fees = selectCompanyFees(company)
+    const fees = selectCompanyFees({ company, defaultRecipient })
 
     it('should return the correct response', () => {
       expect(fees).toEqual({
@@ -132,8 +135,9 @@ describe('selectCompanyFees', () => {
       ],
       payment_method: 'credit_card',
     }])
+    const defaultRecipient = {}
 
-    const fees = selectCompanyFees(company)
+    const fees = selectCompanyFees({ company, defaultRecipient })
 
     it('should return the correct response', () => {
       expect(fees).toEqual({
@@ -164,8 +168,9 @@ describe('selectCompanyFees', () => {
         payment_method: 'credit_card',
       },
     ])
+    const defaultRecipient = {}
 
-    const fees = selectCompanyFees(company)
+    const fees = selectCompanyFees({ company, defaultRecipient })
 
     it('should return the correct response', () => {
       expect(fees).toEqual({
@@ -178,5 +183,33 @@ describe('selectCompanyFees', () => {
       })
     })
   })
-})
 
+  describe('when company has defaultRecipient with feePreset set', () => {
+    const company = companyFactory([])
+    const defaultRecipient = {
+      feePreset: {
+        anticipation_rate: 10,
+        mdrs: [
+          {
+            capture_method: 'ecommerce',
+            installments: [{ installment: 1, mdr: 2 }],
+            payment_method: 'credit_card',
+          },
+        ],
+      },
+    }
+
+    const fees = selectCompanyFees({ company, defaultRecipient })
+
+    it('should return the correct response', () => {
+      expect(fees).toEqual({
+        anticipation: 10,
+        antifraud: 70,
+        boleto: 380,
+        gateway: 50,
+        installments: [{ installment: 1, mdr: 2 }],
+        transfer: 367,
+      })
+    })
+  })
+})

--- a/packages/pilot/src/pages/CompanySettings/index.js
+++ b/packages/pilot/src/pages/CompanySettings/index.js
@@ -27,17 +27,17 @@ import CompanySettings from '../../containers/Settings/Company'
 import environment from '../../environment'
 import isCompanyPaymentLink from '../../validation/isPaymentLink'
 
-import { selectCompanyFees } from '../Account/actions/reducer'
+import { selectCompanyFees, selectAnticipationType } from '../Account/actions/reducer'
 
 const mapStateToProps = ({
   account: {
     client, company, defaultRecipient, user,
   },
 }) => ({
+  anticipationType: selectAnticipationType({ company, defaultRecipient }),
   client,
   company,
   fees: selectCompanyFees({ company, defaultRecipient }),
-  isMDRzao: company && propEq('anticipationType', 'MDRZAO', company),
   user,
 })
 
@@ -582,9 +582,9 @@ class CompanySettingsPage extends React.Component {
 
   render () {
     const {
+      anticipationType,
       company,
       fees,
-      isMDRzao,
       t,
       user,
     } = this.props
@@ -632,7 +632,7 @@ class CompanySettingsPage extends React.Component {
         general={general}
         handleCreateUser={this.handleCreateUser}
         handleDeleteUser={this.handleDeleteUser}
-        isMDRzao={isMDRzao}
+        isMDRzao={anticipationType === 'compulsory'}
         managingPartner={managingPartner}
         onBankAccountCancel={this.handleAccountCancel}
         onBankAccountChange={this.handleAccountChange}
@@ -653,6 +653,7 @@ class CompanySettingsPage extends React.Component {
 }
 
 CompanySettingsPage.propTypes = {
+  anticipationType: PropTypes.string,
   client: PropTypes.shape({
     company: PropTypes.shape({
       info: PropTypes.func.isRequired,
@@ -683,16 +684,15 @@ CompanySettingsPage.propTypes = {
     })),
     transfer: PropTypes.number,
   }),
-  isMDRzao: PropTypes.bool,
   requestLogout: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   user: PropTypes.shape({}),
 }
 
 CompanySettingsPage.defaultProps = {
+  anticipationType: '',
   company: null,
   fees: {},
-  isMDRzao: false,
   user: null,
 }
 

--- a/packages/pilot/src/pages/CompanySettings/index.js
+++ b/packages/pilot/src/pages/CompanySettings/index.js
@@ -30,11 +30,13 @@ import isCompanyPaymentLink from '../../validation/isPaymentLink'
 import { selectCompanyFees } from '../Account/actions/reducer'
 
 const mapStateToProps = ({
-  account: { client, company, user },
+  account: {
+    client, company, defaultRecipient, user,
+  },
 }) => ({
   client,
   company,
-  fees: selectCompanyFees(company),
+  fees: selectCompanyFees({ company, defaultRecipient }),
   isMDRzao: company && propEq('anticipationType', 'MDRZAO', company),
   user,
 })

--- a/packages/pilot/src/pages/EmptyState/EmptyState.js
+++ b/packages/pilot/src/pages/EmptyState/EmptyState.js
@@ -17,7 +17,7 @@ import EmptyStateContainer from '../../containers/EmptyState'
 import { withError } from '../ErrorBoundary'
 import environment from '../../environment'
 
-import { selectCompanyFees } from '../Account/actions/reducer'
+import { selectCompanyFees, selectAnticipationType } from '../Account/actions/reducer'
 
 const getUserName = pipe(prop('name'), split(' '), head)
 
@@ -42,10 +42,10 @@ const mapStateToProps = ({
 }) => ({
   accessKeys: getAccessKeys(company),
   alreadyTransacted: getAlreadyTransacted(company),
+  anticipationType: selectAnticipationType({ company, defaultRecipient }),
   company,
   fees: selectCompanyFees({ company, defaultRecipient }),
   isAdmin: hasAdminPermission(user),
-  isMDRzao: company && propEq('anticipationType', 'MDRZAO', company),
   onboardingAnswers,
   userName: getUserName(user),
 })
@@ -63,12 +63,12 @@ const hideEmptyState = push => () => {
 
 const EmptyState = ({
   accessKeys,
+  anticipationType,
   fees,
   history: {
     push,
   },
   isAdmin,
-  isMDRzao,
   onboardingAnswers,
   t,
   userName,
@@ -79,7 +79,7 @@ const EmptyState = ({
     environment={environment}
     fees={fees}
     isAdmin={isAdmin}
-    isMDRzao={isMDRzao}
+    isMDRzao={anticipationType === 'compulsory'}
     onboardingAnswers={onboardingAnswers}
     onDisableWelcome={hideEmptyState(push)}
     t={t}
@@ -92,6 +92,7 @@ EmptyState.propTypes = {
     apiKey: PropTypes.string,
     encryptionKey: PropTypes.string,
   }),
+  anticipationType: PropTypes.string,
   fees: PropTypes.shape({
     anticipation: PropTypes.number,
     antifraud: PropTypes.number,
@@ -107,7 +108,6 @@ EmptyState.propTypes = {
     push: PropTypes.func.isRequired,
   }).isRequired,
   isAdmin: PropTypes.bool.isRequired,
-  isMDRzao: PropTypes.bool,
   onboardingAnswers: PropTypes.shape({}),
   t: PropTypes.func.isRequired,
   userName: PropTypes.string,
@@ -115,8 +115,8 @@ EmptyState.propTypes = {
 
 EmptyState.defaultProps = {
   accessKeys: {},
+  anticipationType: '',
   fees: {},
-  isMDRzao: false,
   onboardingAnswers: undefined,
   userName: '',
 }

--- a/packages/pilot/src/pages/EmptyState/EmptyState.js
+++ b/packages/pilot/src/pages/EmptyState/EmptyState.js
@@ -33,6 +33,7 @@ const getAlreadyTransacted = propOr(true, 'alreadyTransacted')
 const mapStateToProps = ({
   account: {
     company,
+    defaultRecipient,
     user,
   },
   welcome: {
@@ -42,7 +43,7 @@ const mapStateToProps = ({
   accessKeys: getAccessKeys(company),
   alreadyTransacted: getAlreadyTransacted(company),
   company,
-  fees: selectCompanyFees(company),
+  fees: selectCompanyFees({ company, defaultRecipient }),
   isAdmin: hasAdminPermission(user),
   isMDRzao: company && propEq('anticipationType', 'MDRZAO', company),
   onboardingAnswers,

--- a/packages/pilot/stories/containers/Onboarding/index.js
+++ b/packages/pilot/stories/containers/Onboarding/index.js
@@ -83,6 +83,7 @@ const MacroSegmentsOptions = () => (
         notFoundText="Não encontrei o segmento do meu negócio"
         images={mocks.macroSegmentOptions.images}
         options={mocks.macroSegmentOptions.options}
+        t={t => t}
       />
     </div>
   </Section>

--- a/packages/pilot/stories/containers/Onboarding/mocks.js
+++ b/packages/pilot/stories/containers/Onboarding/mocks.js
@@ -16,15 +16,7 @@ export default {
       FoodIcon,
       PlusIcon,
     ],
-    options: [
-      {
-        category: 'food',
-        label: 'Alimentos',
-      }, {
-        category: 'others',
-        label: 'Outros',
-      },
-    ],
+    options: ['Alimentos', 'Outros'],
   },
   segmentOptions: [
     { label: 'Gráficas', value: 'graficas' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13284,10 +13284,10 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-pagarme@4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/pagarme/-/pagarme-4.12.0.tgz#651f8644219766298a28ae215df958be6649141e"
-  integrity sha512-YJkEZJHyZAPEMpAolE3T/f7jjGrJ5coFH4oqRe0q6ZG40ucYJRCX13J9z01p0cjgbGV+Ddo0LOq+HDfjItbu0A==
+pagarme@4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/pagarme/-/pagarme-4.13.0.tgz#f15cd9186f5df6072acc82ce12834e7fef2f5b0e"
+  integrity sha512-5fOQTyw8pCbJvbqXdjlakKs2IU70vghcyalXZHMFSyO2vPJtzKpWbYnXC5EzAvF/zfNhRhuIIOGZZR4FAO4Vqw==
 
 pako@~1.0.5:
   version "1.0.10"


### PR DESCRIPTION
## Contexto

 As taxas de MDR dos clientes atualmente estão cadastradas em dois locais: dentro da company e na tabela feePreset. Foi pedido para alterarmos a forma como cadastramos os clientes com antecipação compulsoria na plataforma para, ao inves de buscar cadastrar as taxas nas companies, realizarmos os cadastro na tabela feePreset.

Entretanto, as taxas ainda existirão dentro da company e serão utilizadas como um fallback. Se houver taxas no feePreset, serão usadas as taxas do feePreset, caso não exista feePreset configurado para o recebedor, serão usadas as taxas da company.

Desta forma, este PR altera a busca das taxas que são aplicadas no cliente, priorizando primeiro a informação do feePreset, e, caso não exista, usando a informação da company.

## Checklist
- [ ] Altera a busca de taxas que são aplicadas na company.

## Issues linkadas
- [ ] Resolves [CRED-225](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=186&projectKey=CRED&modal=detail&selectedIssue=CRED-225)
