### PR TITLE
Corrigi o calculo de antecipação

### DIFF
--- a/packages/pilot/src/pages/Anticipation/Anticipation.js
+++ b/packages/pilot/src/pages/Anticipation/Anticipation.js
@@ -202,7 +202,6 @@ const initialState = {
   feesValues: {
     anticipation: 0,
     fraud: 0,
-    otherFee: 0,
   },
   invalidDays: [],
   isAutomaticTransfer: true,
@@ -581,13 +580,12 @@ class Anticipation extends Component {
         status,
       }) => {
         this.setState({
-          approximateRequested: amount,
+          approximateRequested: amount - fee,
           bulkAnticipationStatus: status,
           error: null,
           feesValues: {
             anticipation: anticipationFee,
             fraud: fraudCoverageFee,
-            otherFee: fee,
           },
           isAutomaticTransfer,
           needsRecalculation: false,
@@ -732,12 +730,11 @@ class Anticipation extends Component {
       } = bulk
 
       this.setState({
-        approximateRequested: amount,
+        approximateRequested: amount - fee,
         error: null,
         feesValues: {
           anticipation: anticipationFee,
           fraud: fraudCovarageFee,
-          otherFee: fee,
         },
         loading: false,
         needsRecalculation: false,
@@ -816,14 +813,13 @@ class Anticipation extends Component {
         status,
       }) => {
         this.setState({
-          approximateRequested: amount,
+          approximateRequested: amount - fee,
           bulkAnticipationStatus: status,
           bulkId: id,
           error: null,
           feesValues: {
             anticipation: anticipationFee,
             fraud: fraudCovarageFee,
-            otherFee: fee,
           },
           loading: false,
           requestedAmount: max,
@@ -840,7 +836,6 @@ class Anticipation extends Component {
       feesValues: {
         anticipation,
         fraud,
-        otherFee,
       },
       isAutomaticTransfer,
       loading,
@@ -866,7 +861,7 @@ class Anticipation extends Component {
       t,
     } = this.props
 
-    const totalCost = -(anticipation + fraud + otherFee)
+    const totalCost = -(anticipation + fraud)
     const totalCostAndTransfer = totalCost + transferCost
     const amount = approximateRequested
       ? approximateRequested + totalCostAndTransfer


### PR DESCRIPTION
## Contexto

Na tela de criar a antecipação dos clientes, o valor a ser antecipado está sendo montado com base na resposta do endponit  [`POST /recipient/:recipientId/bulk_anticipation`](https://docs.pagar.me/reference#criando-uma-antecipa%C3%A7%C3%A3o).

Atualmente está sendo utilizado a soma das propriedades `anticipation_fee` e `fee` para exibir o custo da antecipação do cliente. Entretanto, o `fee` se refere ao MDR e nao ao custo de antecipacao, e isto [acaba confundindo os clientes](https://pagarme.slack.com/archives/C3LUBHK5J/p1599057539050700) principalmente por diferir do comportamento da dashboard antiga.

## Checklist
- [ ] Corrige o calculo da taxa de antecipação.

## Issues linkadas
- [ ] Resolves #
<!-- Adicione as respectivas issues linkadas a este PR. -->
