### PR TITLE
CRED-291 - plinks: update set expiration_in as optional

### DIFF
--- a/packages/pilot/public/locales/pt/translations.json
+++ b/packages/pilot/public/locales/pt/translations.json
@@ -1726,7 +1726,7 @@
           "title": "Criar link de pagamentos",
           "price_form_label": "Preço (R$)",
           "link_name_label": "Nome do link",
-          "time_expiration_form_label": "Tempo de expiração",
+          "time_expiration_form_label": "Tempo de expiração (opcional)",
           "expiration_date_string": "Este link ficará disponível até {{formatedDate}} às {{formatedHours}}.",
           "min_chars_length_error": "Este campo precisa ter no mínimo {{length}} caracteres.",
           "max_chars_length_error": "No máximo {{length}} caracteres",

--- a/packages/pilot/src/containers/PaymentLinks/List/PaymentLinkAdd/FirstStep/validators.js
+++ b/packages/pilot/src/containers/PaymentLinks/List/PaymentLinkAdd/FirstStep/validators.js
@@ -39,7 +39,11 @@ const createMaxAllowedDays = (timeUnit, getTranslation) => (timeAmount) => {
 
 export const validateExpirationAmount = (
   expirationUnit, getTranslation
-) => (value = 0) => {
+) => (value) => {
+  if (!value) {
+    return false
+  }
+
   const isNumber = createNumberValidation(getTranslation('is_not_integer_error'))
   const minAllowedHours = createMinAllowedHours(expirationUnit, getTranslation)
   const maxAllowedDays = createMaxAllowedDays(expirationUnit, getTranslation)

--- a/packages/pilot/src/formatters/paymentLinkSpec.js
+++ b/packages/pilot/src/formatters/paymentLinkSpec.js
@@ -17,6 +17,10 @@ const expiresIn = ({
   expiration_amount: expirationAmount,
   expiration_unit: expirationUnit,
 }) => {
+  if (!expirationAmount) {
+    return undefined
+  }
+
   const date = moment()
   const expirationDate = date.clone().add(expirationAmount, expirationUnit)
   const duration = moment.duration(expirationDate.diff(date))


### PR DESCRIPTION
## Contexto

Este PR seta o campo de tempo de expiração do link de pagamento como opcional. Desta forma, criando links com prazo indeterminado.

## Checklist
- [ ] Seta o campo de tempo de expiração do link de pagamento como opcional. Desta forma, criando links com prazo indeterminado.

## Issues linkadas
- [ ] [CRED-291](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=186&projectKey=CRED&modal=detail&selectedIssue=CRED-291)
