### PR TITLE
chore: validate recipient status

### DIFF
--- a/packages/pilot/src/containers/RecipientTable/statusLegend.js
+++ b/packages/pilot/src/containers/RecipientTable/statusLegend.js
@@ -14,6 +14,10 @@ const StatusLegend = ({
     ? 'pages.recipients.status_acronym_of'
     : 'pages.recipients.status_of'
 
+  if (!item.status) {
+    return null
+  }
+
   return (
     <div className={style.centralizedItem}>
       <Legend


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
Quando a company possui um recebedor com um status inválido não é possível abrir a aba de recebedores.

## Checklist
- [x] Caso não seja um status válido remover a legenda do status.
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [x] [Issue](https://mundipagg.atlassian.net/browse/CRED-369)
<!-- Adicione as respectivas issues linkadas a este PR. -->

